### PR TITLE
Added paymentPurpose as accepted feedback field in updateDocument:

### DIFF
--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -96,7 +96,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
         NSDictionary *extractions = task.result;
         NSMutableDictionary *updateExtractions = [NSMutableDictionary new];
         
-        NSArray *keys = @[@"paymentReference", @"iban", @"bic", @"amountToPay", @"paymentRecipient"];
+        NSArray *keys = @[@"paymentReference", @"iban", @"bic", @"amountToPay", @"paymentRecipient", @"paymentPurpose"];
         for (NSString *key in extractions) {
             if ([keys containsObject:key]) {
                 GINIExtraction *extraction = extractions[key];


### PR DESCRIPTION
# Information

For clients that have two fields - payment reference and payment purpose, it was impossible to send both as feedback. Therefore, we've added "paymentPurpose" in the list of accepted feedback fields.

# How to test

In a test app (you can even use the Gini Vision Library Example), try to send feedback on an extraction using "paymentPurpose" as field name.

# Merge info

Automatic 