### PR TITLE
Add support for pinning with several certificates

### DIFF
--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+0.5.1 (14-12-2017)
+==================
+
+Features
+--------
+
+- Added support for pinning with more than one certificate.
+
 0.5.0 (12-12-2017)
 ==================
 

--- a/Gini-iOS-SDK/GINISDKBuilder.h
+++ b/Gini-iOS-SDK/GINISDKBuilder.h
@@ -35,11 +35,11 @@
  *                          you registered with Gini.
  *
  * @param clientID          The application's client ID for the Gini API.
- * @param certificatePath   Local certificate path for certificate pinning.
+ * @param certificatePaths  Local certificate paths for certificate pinning.
  */
 + (instancetype)clientFlowWithClientID:(NSString *)clientID
                              urlScheme:(NSString *)urlScheme
-                       certificatePath:(NSString *)certificatePath;
+                      certificatePaths:(NSArray<NSString *> *) certificatePaths;
 
 /**
  * Creates an instance of the GINISDKBuilder where the server authorization flow is used.
@@ -67,12 +67,12 @@
  * @param clientID          The application's client ID for the Gini API.
  *
  * @param clientSecret      The client secret you received from Gini.
- * @param certificatePath   Local certificate path for certificate pinning.
+ * @param certificatePaths  Local certificate paths for certificate pinning.
  */
 + (instancetype)serverFlowWithClientID:(NSString *)clientID
                           clientSecret:(NSString *)clientSecret
                              urlScheme:(NSString *)urlScheme
-                       certificatePath:(NSString *)certificatePath;
+                      certificatePaths:(NSArray<NSString *> *) certificatePaths;
 
 /**
  * Creates an instance of the GINISDKBuilder where anonymous users are used.
@@ -94,7 +94,7 @@
  * @param clientId          The application's clientID for the Gini API.
  *
  * @param emailDomain       The domain of the email address.
- * @param certificatePath   Local certificate path for certificate pinning.
+ * @param certificatePaths  Local certificate paths for certificate pinning.
  *
  * @warning: This requires access to the Gini User Center API. Access to the User Center API is restricted to selected
  * clients only.
@@ -102,7 +102,7 @@
 + (instancetype)anonymousUserWithClientID:(NSString *)clientId
                              clientSecret:(NSString *)clientSecret
                           userEmailDomain:(NSString *)emailDomain
-                          certificatePath:(NSString *)certificatePath;
+                         certificatePaths:(NSArray<NSString *> *) certificatePaths;
 
 
 /**

--- a/Gini-iOS-SDK/GINISDKBuilder.h
+++ b/Gini-iOS-SDK/GINISDKBuilder.h
@@ -39,7 +39,7 @@
  */
 + (instancetype)clientFlowWithClientID:(NSString *)clientID
                              urlScheme:(NSString *)urlScheme
-                      certificatePaths:(NSArray<NSString *> *) certificatePaths;
+                      certificatePaths:(NSArray<NSString *> *)certificatePaths;
 
 /**
  * Creates an instance of the GINISDKBuilder where the server authorization flow is used.
@@ -72,7 +72,7 @@
 + (instancetype)serverFlowWithClientID:(NSString *)clientID
                           clientSecret:(NSString *)clientSecret
                              urlScheme:(NSString *)urlScheme
-                      certificatePaths:(NSArray<NSString *> *) certificatePaths;
+                      certificatePaths:(NSArray<NSString *> *)certificatePaths;
 
 /**
  * Creates an instance of the GINISDKBuilder where anonymous users are used.
@@ -102,7 +102,7 @@
 + (instancetype)anonymousUserWithClientID:(NSString *)clientId
                              clientSecret:(NSString *)clientSecret
                           userEmailDomain:(NSString *)emailDomain
-                         certificatePaths:(NSArray<NSString *> *) certificatePaths;
+                         certificatePaths:(NSArray<NSString *> *)certificatePaths;
 
 
 /**

--- a/Gini-iOS-SDK/GINISDKBuilder.m
+++ b/Gini-iOS-SDK/GINISDKBuilder.m
@@ -82,7 +82,7 @@ GINIInjector* GINIDefaultInjector() {
 }
 
 + (instancetype)clientFlowWithClientID:(NSString *)clientID urlScheme:(NSString *)urlScheme
-                              certificatePaths:(NSArray<NSString *> *) certificatePaths {
+                              certificatePaths:(NSArray<NSString *> *)certificatePaths {
     NSParameterAssert([clientID isKindOfClass:[NSString class]]);
     NSParameterAssert([urlScheme isKindOfClass:[NSString class]]);
     
@@ -94,7 +94,7 @@ GINIInjector* GINIDefaultInjector() {
 }
 
 + (instancetype)serverFlowWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret urlScheme:(NSString *)urlScheme
-                              certificatePaths:(NSArray<NSString *> *) certificatePaths {
+                              certificatePaths:(NSArray<NSString *> *)certificatePaths {
     NSParameterAssert([clientID isKindOfClass:[NSString class]]);
     NSParameterAssert([clientSecret isKindOfClass:[NSString class]]);
     NSParameterAssert([urlScheme isKindOfClass:[NSString class]]);
@@ -109,7 +109,7 @@ GINIInjector* GINIDefaultInjector() {
 }
 
 + (instancetype)anonymousUserWithClientID:(NSString *)clientId clientSecret:(NSString *)clientSecret userEmailDomain:(NSString *)emailDomain
-                                 certificatePaths:(NSArray<NSString *> *) certificatePaths {
+                                 certificatePaths:(NSArray<NSString *> *)certificatePaths {
     NSParameterAssert([clientId isKindOfClass:[NSString class]]);
     NSParameterAssert([emailDomain isKindOfClass:[NSString class]]);
     NSParameterAssert([clientSecret isKindOfClass:[NSString class]]);
@@ -127,7 +127,7 @@ GINIInjector* GINIDefaultInjector() {
 }
 
 - (instancetype)initWithClientID:(NSString *)clientID urlScheme:(NSString *)urlScheme clientSecret:(NSString *)clientSecret
-                        certificatePaths:(NSArray<NSString *> *) certificatePaths {
+                        certificatePaths:(NSArray<NSString *> *)certificatePaths {
     NSParameterAssert([clientID isKindOfClass:[NSString class]]);
 
     if (self = [super init]) {

--- a/Gini-iOS-SDK/GINISDKBuilder.m
+++ b/Gini-iOS-SDK/GINISDKBuilder.m
@@ -140,11 +140,11 @@ GINIInjector* GINIDefaultInjector() {
             [_injector setObject:clientSecret forKey:GINIInjectorClientSecretKey];
         }
         if (certificatePaths != nil) {
-            [_injector setObject:certificatePaths forKey:GINIInjectorCertificatePathKey];
+            [_injector setObject:certificatePaths forKey:GINIInjectorCertificatePathsKey];
             [_injector setSingletonFactory:@selector(urlSessionDelegateWithCertificatePaths:)
                                        on:[GINIURLSessionDelegate class]
                                    forKey:@protocol(GINIURLSessionDelegate)
-                         withDependencies: GINIInjectorCertificatePathKey, nil];
+                         withDependencies: GINIInjectorCertificatePathsKey, nil];
             NSArray *dependencies = [NSArray arrayWithObjects: @protocol(GINIURLSessionDelegate), nil];
             [[_injector factoryForKey:GINIInjectorKey(@protocol(GINIURLSession))]setDependencies:dependencies];
         }

--- a/Gini-iOS-SDK/GINISDKBuilder.m
+++ b/Gini-iOS-SDK/GINISDKBuilder.m
@@ -78,43 +78,43 @@ GINIInjector* GINIDefaultInjector() {
 
 #pragma mark - Factories
 + (instancetype)clientFlowWithClientID:(NSString *)clientID urlScheme:(NSString *)urlScheme {
-    return [self clientFlowWithClientID:clientID urlScheme:urlScheme certificatePath:nil];
+    return [self clientFlowWithClientID:clientID urlScheme:urlScheme certificatePaths:nil];
 }
 
 + (instancetype)clientFlowWithClientID:(NSString *)clientID urlScheme:(NSString *)urlScheme
-                              certificatePath:(NSString *)certificatePath {
+                              certificatePaths:(NSArray<NSString *> *) certificatePaths {
     NSParameterAssert([clientID isKindOfClass:[NSString class]]);
     NSParameterAssert([urlScheme isKindOfClass:[NSString class]]);
     
-    return [[self alloc] initWithClientID:clientID urlScheme:urlScheme clientSecret:nil certificatePath:certificatePath];
+    return [[self alloc] initWithClientID:clientID urlScheme:urlScheme clientSecret:nil certificatePaths:certificatePaths];
 }
 
 + (instancetype)serverFlowWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret urlScheme:(NSString *)urlScheme {
-    return [self serverFlowWithClientID:clientID clientSecret:clientSecret urlScheme:urlScheme certificatePath:nil];
+    return [self serverFlowWithClientID:clientID clientSecret:clientSecret urlScheme:urlScheme certificatePaths:nil];
 }
 
 + (instancetype)serverFlowWithClientID:(NSString *)clientID clientSecret:(NSString *)clientSecret urlScheme:(NSString *)urlScheme
-                              certificatePath:(NSString *)certificatePath {
+                              certificatePaths:(NSArray<NSString *> *) certificatePaths {
     NSParameterAssert([clientID isKindOfClass:[NSString class]]);
     NSParameterAssert([clientSecret isKindOfClass:[NSString class]]);
     NSParameterAssert([urlScheme isKindOfClass:[NSString class]]);
     
-    GINISDKBuilder *instance = [[self alloc] initWithClientID:clientID urlScheme:urlScheme clientSecret:clientSecret certificatePath:certificatePath];
+    GINISDKBuilder *instance = [[self alloc] initWithClientID:clientID urlScheme:urlScheme clientSecret:clientSecret certificatePaths:certificatePaths];
     [instance useServerFlow];
     return instance;
 }
 
 + (instancetype)anonymousUserWithClientID:(NSString *)clientId clientSecret:(NSString *)clientSecret userEmailDomain:(NSString *)emailDomain {
-    return [self anonymousUserWithClientID:clientId clientSecret:clientSecret userEmailDomain:emailDomain certificatePath:nil];
+    return [self anonymousUserWithClientID:clientId clientSecret:clientSecret userEmailDomain:emailDomain certificatePaths:nil];
 }
 
 + (instancetype)anonymousUserWithClientID:(NSString *)clientId clientSecret:(NSString *)clientSecret userEmailDomain:(NSString *)emailDomain
-                                 certificatePath:(NSString *)certificatePath {
+                                 certificatePaths:(NSArray<NSString *> *) certificatePaths {
     NSParameterAssert([clientId isKindOfClass:[NSString class]]);
     NSParameterAssert([emailDomain isKindOfClass:[NSString class]]);
     NSParameterAssert([clientSecret isKindOfClass:[NSString class]]);
     
-    GINISDKBuilder *instance = [[self alloc] initWithClientID:clientId urlScheme:nil clientSecret:clientSecret certificatePath:certificatePath];
+    GINISDKBuilder *instance = [[self alloc] initWithClientID:clientId urlScheme:nil clientSecret:clientSecret certificatePaths:certificatePaths];
     [instance useAnonymousUser:emailDomain];
     return instance;
 }
@@ -127,7 +127,7 @@ GINIInjector* GINIDefaultInjector() {
 }
 
 - (instancetype)initWithClientID:(NSString *)clientID urlScheme:(NSString *)urlScheme clientSecret:(NSString *)clientSecret
-                        certificatePath:(NSString *)certificatePath {
+                        certificatePaths:(NSArray<NSString *> *) certificatePaths {
     NSParameterAssert([clientID isKindOfClass:[NSString class]]);
 
     if (self = [super init]) {
@@ -139,9 +139,9 @@ GINIInjector* GINIDefaultInjector() {
         if (clientSecret != nil) {
             [_injector setObject:clientSecret forKey:GINIInjectorClientSecretKey];
         }
-        if (certificatePath != nil) {
-            [_injector setObject:certificatePath forKey:GINIInjectorCertificatePathKey];
-            [_injector setSingletonFactory:@selector(urlSessionDelegateWithCertificatePath:)
+        if (certificatePaths != nil) {
+            [_injector setObject:certificatePaths forKey:GINIInjectorCertificatePathKey];
+            [_injector setSingletonFactory:@selector(urlSessionDelegateWithCertificatePaths:)
                                        on:[GINIURLSessionDelegate class]
                                    forKey:@protocol(GINIURLSessionDelegate)
                          withDependencies: GINIInjectorCertificatePathKey, nil];

--- a/Gini-iOS-SDK/GINIURLSessionDelegate.h
+++ b/Gini-iOS-SDK/GINIURLSessionDelegate.h
@@ -12,6 +12,6 @@
 
 @interface GINIURLSessionDelegate : NSObject <NSURLSessionDelegate>
 
-+ (instancetype)urlSessionDelegateWithCertificatePath:(NSString *)certificatePath;
++ (instancetype)urlSessionDelegateWithCertificatePaths:(NSArray<NSString *> *) certificatePaths;
 
 @end

--- a/Gini-iOS-SDK/GINIURLSessionDelegate.h
+++ b/Gini-iOS-SDK/GINIURLSessionDelegate.h
@@ -12,6 +12,6 @@
 
 @interface GINIURLSessionDelegate : NSObject <NSURLSessionDelegate>
 
-+ (instancetype)urlSessionDelegateWithCertificatePaths:(NSArray<NSString *> *) certificatePaths;
++ (instancetype)urlSessionDelegateWithCertificatePaths:(NSArray<NSString *> *)certificatePaths;
 
 @end

--- a/Gini-iOS-SDK/GINIURLSessionDelegate.m
+++ b/Gini-iOS-SDK/GINIURLSessionDelegate.m
@@ -45,17 +45,12 @@ completionHandler {
         SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, i);
         NSData *remoteCertificateData = (NSData *)CFBridgingRelease(SecCertificateCopyData(certificate));
         
-        for (int j = 0; j < [_nsCertificatePaths count]; j++) {
-            NSData *localCertificate = [NSData dataWithContentsOfFile:[_nsCertificatePaths objectAtIndex:j]];
-            if(localCertificate != nil) {
-                remoteCertEqualToLocalCert = [remoteCertificateData isEqualToData:localCertificate];
-                if (remoteCertEqualToLocalCert) {
-                    goto outer_done;
-                }
-            }
+        remoteCertEqualToLocalCert = [self isLocalCertEqualToRemoteCertData:remoteCertificateData];
+        
+        if (remoteCertEqualToLocalCert) {
+            break;
         }
     }
-    outer_done:;
     
     if ((remoteCertEqualToLocalCert && remoteCertificateIsValid) || _nsCertificatePaths == nil ) {
         NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
@@ -63,6 +58,16 @@ completionHandler {
     } else {
         completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, NULL);
     }
+}
+
+- (BOOL)isLocalCertEqualToRemoteCertData:(NSData *)data {
+    for (int j = 0; j < [_nsCertificatePaths count]; j++) {
+        NSData *localCertificate = [NSData dataWithContentsOfFile:[_nsCertificatePaths objectAtIndex:j]];
+        if(localCertificate != nil && [data isEqualToData:localCertificate]) {
+            return true;
+        }
+    }
+    return false;
 }
 
 @end

--- a/Gini-iOS-SDK/GINIURLSessionDelegate.m
+++ b/Gini-iOS-SDK/GINIURLSessionDelegate.m
@@ -12,11 +12,11 @@
     NSArray<NSString *> *_nsCertificatePaths;
 }
 
-+ (instancetype)urlSessionDelegateWithCertificatePaths:(NSArray<NSString *> *) certificatePaths {
++ (instancetype)urlSessionDelegateWithCertificatePaths:(NSArray<NSString *> *)certificatePaths {
     return [[self alloc] initWithNSURLSessionDelegate:certificatePaths];
 }
 
-- (instancetype)initWithNSURLSessionDelegate:(NSArray<NSString *> *) certificatePaths {
+- (instancetype)initWithNSURLSessionDelegate:(NSArray<NSString *> *)certificatePaths {
     self = [super init];
     if (self) {
         _nsCertificatePaths = certificatePaths;

--- a/Gini-iOS-SDK/GINIURLSessionDelegate.m
+++ b/Gini-iOS-SDK/GINIURLSessionDelegate.m
@@ -9,17 +9,17 @@
 #import "GINIURLSessionDelegate.h"
 
 @implementation GINIURLSessionDelegate {
-    NSString *_nsCertificatePath;
+    NSArray<NSString *> *_nsCertificatePaths;
 }
 
-+ (instancetype)urlSessionDelegateWithCertificatePath:(NSString *)certificatePath {
-    return [[self alloc] initWithNSURLSessionDelegate:certificatePath];
++ (instancetype)urlSessionDelegateWithCertificatePaths:(NSArray<NSString *> *) certificatePaths {
+    return [[self alloc] initWithNSURLSessionDelegate:certificatePaths];
 }
 
-- (instancetype)initWithNSURLSessionDelegate:(NSString *)certificatePath {
+- (instancetype)initWithNSURLSessionDelegate:(NSArray<NSString *> *) certificatePaths {
     self = [super init];
     if (self) {
-        _nsCertificatePath = certificatePath;
+        _nsCertificatePaths = certificatePaths;
     }
     return self;
 }
@@ -27,8 +27,7 @@
 -(void)URLSession:(NSURLSession *)session
 didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge
 completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))
-completionHandler {
-    
+completionHandler {    
     SecTrustRef serverTrust = challenge.protectionSpace.serverTrust;
     SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, 0);
     
@@ -42,9 +41,9 @@ completionHandler {
     BOOL certificateIsValid = (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
     
     NSData *remoteCertificateData = CFBridgingRelease(SecCertificateCopyData(certificate));
-    NSData *localCertificate = [NSData dataWithContentsOfFile:_nsCertificatePath];
+    NSData *localCertificate = [NSData dataWithContentsOfFile:_nsCertificatePaths];
     
-    if (([remoteCertificateData isEqualToData:localCertificate] && certificateIsValid) || _nsCertificatePath == nil ) {
+    if (([remoteCertificateData isEqualToData:localCertificate] && certificateIsValid) || _nsCertificatePaths == nil ) {
         NSURLCredential *credential = [NSURLCredential credentialForTrust:serverTrust];
         completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
     } else {

--- a/Gini-iOS-SDK/GiniSDK.h
+++ b/Gini-iOS-SDK/GiniSDK.h
@@ -37,8 +37,8 @@ FOUNDATION_EXPORT NSString *const GINIInjectorURLSchemeKey;
 FOUNDATION_EXPORT NSString *const GINIInjectorClientIDKey;
 /// Use this key to identify the application's client secret in the injector.
 FOUNDATION_EXPORT NSString *const GINIInjectorClientSecretKey;
-/// Use this key to identify the application's cert path in the injector.
-FOUNDATION_EXPORT NSString *const GINIInjectorCertificatePathKey;
+/// Use this key to identify the application's certificate paths in the injector.
+FOUNDATION_EXPORT NSString *const GINIInjectorCertificatePathsKey;
 
 /**
  * The Gini SDK.

--- a/Gini-iOS-SDK/GiniSDK.m
+++ b/Gini-iOS-SDK/GiniSDK.m
@@ -10,7 +10,7 @@ NSString *const GINIInjectorUserBaseURLKey = @"UserBaseURL";
 NSString *const GINIInjectorURLSchemeKey = @"AppURLScheme";
 NSString *const GINIInjectorClientSecretKey = @"AppClientSecret";
 NSString *const GINIInjectorClientIDKey = @"AppClientId";
-NSString *const GINIInjectorCertificatePathKey = @"CertificatePath";
+NSString *const GINIInjectorCertificatePathsKey = @"CertificatePaths";
 
 
 @implementation GiniSDK{


### PR DESCRIPTION
Add support for pinning with more than one certificate.

### How to test
Create GINI SDK instance passing your certificate paths. If there is a match between remote and local certificates, all requests to the API will work.

### Merging
Automatic.

### Ticket 
Issue #55 