### PR TITLE
Update Bolts and TrustKit, and add cancellation token

### DIFF
--- a/Documentation/source/changelog.rst
+++ b/Documentation/source/changelog.rst
@@ -2,6 +2,17 @@
 Changelog
 =========
 
+1.0.0-alpha.1 (15-03-2018)
+==================
+
+Features
+--------
+
+- Updated Bolts to 1.9.0
+- Updated TrustKit to 1.5.3
+- Added cancellation token.
+
+
 0.6.0 (09-02-2018)
 ==================
 

--- a/Gini-iOS-SDK.podspec
+++ b/Gini-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name     = 'Gini-iOS-SDK'
-s.version  = '0.6.0'
+s.version  = '1.0.0-alpha.1'
 s.license  = 'MIT'
 s.summary  = 'An SDK for integrating the magical Gini technology into other apps.'
 s.homepage = 'https://github.com/gini/gini-sdk-ios'

--- a/Gini-iOS-SDK.podspec
+++ b/Gini-iOS-SDK.podspec
@@ -15,13 +15,13 @@ s.source_files = 'Gini-iOS-SDK'
 s.default_subspec = 'Core'
 
 s.subspec 'Core' do |core|
-core.dependency "Bolts", "~> 1.1.5"
+core.dependency "Bolts", "~> 1.9"
 end
 
 s.subspec 'Pinning' do |pinning|
 pinning.xcconfig =
 { 'OTHER_CFLAGS' => '$(inherited) -DPINNING_AVAILABLE' }
-pinning.dependency "TrustKit", "~> 1.5.2"
-pinning.dependency "Bolts", "~> 1.1.5"
+pinning.dependency "TrustKit", "~> 1.5"
+pinning.dependency "Bolts", "~> 1.9"
 end
 end

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -4,6 +4,7 @@
  */
 
 @class BFTask;
+@class BFCancellationToken;
 @protocol GINIAPIManagerRequestFactory;
 @protocol GINIURLSession;
 
@@ -61,12 +62,35 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 - (BFTask *)getDocument:(NSString *)documentId;
 
 /**
+ * Gets the document with the given ID.
+ *
+ * @param documentId               The document's ID.
+ * @param cancellationToken        Cancellation token used to cancel the current task.
+
+ *
+ * @returns                        A `BFTask*` that will resolve to a NSDictionary* containing the API's response.
+ */
+- (BFTask *)getDocument:(NSString *)documentId
+      cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
  * Gets the document with the given URL.
  *
  * @param location          The document's location.
  * @returns                 A `BFTask*` that will resolve to a NSDictionary* containing the API's response.
  */
 - (BFTask *)getDocumentWithURL:(NSURL *)location;
+
+/**
+ * Gets the document with the given URL.
+ *
+ * @param location                 The document's location.
+ * @param cancellationToken        Cancellation token used to cancel the current task.
+ *
+ * @returns                        A `BFTask*` that will resolve to a NSDictionary* containing the API's response.
+ */
+- (BFTask *)getDocumentWithURL:(NSURL *)location
+             cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Gets the rendered preview of a document page.
@@ -79,7 +103,26 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  *
  * @returns                 A `BFTask*` that will resolve to an UIImage* containing the preview image.
  */
-- (BFTask *)getPreviewForPage:(NSUInteger)pageNumber ofDocument:(NSString *)documentId withSize:(GiniApiPreviewSize)size;
+- (BFTask *)getPreviewForPage:(NSUInteger)pageNumber
+                   ofDocument:(NSString *)documentId
+                     withSize:(GiniApiPreviewSize)size;
+
+/**
+ * Gets the rendered preview of a document page.
+ *
+ * @param pageNumber        The page number of the page of which the preview image is wanted (index starting with 1).
+ * @param documentId        The document's unique identifier.
+ * @param cancellationToken Cancellation token used to cancel the current task.
+ * @param size              The size of the rendered preview image. Please notice that this is the maximum size,
+ *                          meaning that the images dimensions will not exceeding this limit but the rendered image can
+ *                          actually have a little smaller dimensions.
+ *
+ * @returns                 A `BFTask*` that will resolve to an UIImage* containing the preview image.
+ */
+- (BFTask *)getPreviewForPage:(NSUInteger)pageNumber
+                   ofDocument:(NSString *)documentId
+                     withSize:(GiniApiPreviewSize)size
+            cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Gets the list of pages for a document.
@@ -91,6 +134,17 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 - (BFTask *)getPagesForDocument:(NSString *)documentId;
 
 /**
+ * Gets the list of pages for a document.
+ *
+ * @param documentId               The document's id.
+ * @param cancellationToken        Cancellation token used to cancel the current task.
+ *
+ * @returns                        A `BFTask*` that will resolve to an array of pages.
+ */
+- (BFTask *)getPagesForDocument:(NSString *)documentId
+              cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
  * Gets the layout of a document.
  *
  * @param documentId        The document's id.
@@ -98,7 +152,21 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  *
  * @return                  A `BFTask*` that will resolve to a NSDictionary containing the document layout.
  */
-- (BFTask *)getLayoutForDocument:(NSString *)documentId responseType:(GiniAPIResponseType)responseType;
+- (BFTask *)getLayoutForDocument:(NSString *)documentId
+                    responseType:(GiniAPIResponseType)responseType;
+
+/**
+ * Gets the layout of a document.
+ *
+ * @param documentId               The document's id.
+ * @param responseType             The desired response type.
+ * @param cancellationToken        Cancellation token used to cancel the current task.
+ *
+ * @return                         A `BFTask*` that will resolve to a NSDictionary containing the document layout.
+ */
+- (BFTask *)getLayoutForDocument:(NSString *)documentId
+                    responseType:(GiniAPIResponseType)responseType
+               cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Creates a new document from the given NSData*.
@@ -114,7 +182,31 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  *
  * @returns                 A`BFTask*` that will resolve to a NSString containing the created document's ID.
  */
-- (BFTask *)uploadDocumentWithData:(NSData *)documentData contentType:(NSString *)contentType fileName:(NSString *)fileName docType:(NSString *)docType;
+- (BFTask *)uploadDocumentWithData:(NSData *)documentData
+                       contentType:(NSString *)contentType
+                          fileName:(NSString *)fileName
+                           docType:(NSString *)docType;
+
+/**
+ * Creates a new document from the given NSData*.
+ *
+ * @param documentData      Data containing the document. This should be in a format that is supported by the Gini API, see
+ *                          [the Gini API documentation](http://developer.gini.net/gini-api/html/documents.html?highlight=put#supported-file-formats)
+ *                          for details.
+ * @param contentType       The content type of the document (as a MIME string).
+ * @param fileName          The filename of the document.
+ * @param docType           (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
+ *                          [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
+ *                          for a list of possibles doctypes.
+ * @param cancellationToken Cancellation token used to cancel the current task.
+ *
+ * @returns                 A`BFTask*` that will resolve to a NSString containing the created document's ID.
+ */
+- (BFTask *)uploadDocumentWithData:(NSData *)documentData
+                       contentType:(NSString *)contentType
+                          fileName:(NSString *)fileName
+                           docType:(NSString *)docType
+                 cancellationToken:(BFCancellationToken *) cancellationToken;
 
 /**
  * Deletes the document with the given ID.
@@ -126,6 +218,17 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 - (BFTask *)deleteDocument:(NSString *)documentId;
 
 /**
+ * Deletes the document with the given ID.
+ *
+ * @param documentId               The document's id.
+ * @param cancellationToken        Cancellation token used to cancel the current task.
+ *
+ * @returns                        A `BFTask*` with `nil` as result when the document has been deleted.
+ */
+- (BFTask *)deleteDocument:(NSString *)documentId
+         cancellationToken:(BFCancellationToken *) cancellationToken;
+
+/**
  * Gets a list of all documents.
  *
  * @param limit             The maximum number of documents to return.
@@ -133,7 +236,21 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  *
  * @returns                 A `BFTask*` that will resolve to an NSDictionary containing a paginated list of documents.
  */
-- (BFTask *)getDocumentsWithLimit:(NSUInteger)limit offset:(NSUInteger)offset;
+- (BFTask *)getDocumentsWithLimit:(NSUInteger)limit
+                           offset:(NSUInteger)offset;
+
+/**
+ * Gets a list of all documents.
+ *
+ * @param limit                 The maximum number of documents to return.
+ * @param offset                The start offset.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A `BFTask*` that will resolve to an NSDictionary containing a paginated list of documents.
+ */
+- (BFTask *)getDocumentsWithLimit:(NSUInteger)limit
+                           offset:(NSUInteger)offset
+                cancellationToken:(BFCancellationToken *) cancellationToken;
 
 /**
  * Gets extractions for the specific document
@@ -143,6 +260,17 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @returns                 A `BFTask*` that will resolve to an NSDictionary containing the extractions for the document.
  */
 - (BFTask *)getExtractionsForDocument:(NSString *)documentId;
+
+/**
+ * Gets extractions for the specific document
+ *
+ * @param documentId            The document's id.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A `BFTask*` that will resolve to an NSDictionary containing the extractions for the document.
+ */
+- (BFTask *)getExtractionsForDocument:(NSString *)documentId
+                    cancellationToken:(BFCancellationToken *) cancellationToken;
 
 /**
  * Gets the extractions for the specific document, including the incubation extractions (see
@@ -155,6 +283,18 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 - (BFTask *)getIncubatorExtractionsForDocument:(NSString *)documentId;
 
 /**
+ * Gets the extractions for the specific document, including the incubation extractions (see
+ * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
+ *
+ * @param documentId            The document's unique identifier.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A `BFTask*` that will resolve to an NSDictionary containing the extractions for the document.
+ */
+- (BFTask *)getIncubatorExtractionsForDocument:(NSString *)documentId
+                             cancellationToken:(BFCancellationToken *) cancellationToken;
+
+/**
  * Submit feedback for the document on a specific label.
  *
  * @param documentId        The document's id.
@@ -164,7 +304,10 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  *
  * @returns                 A `BFTask*`
  */
-- (BFTask *)submitFeedbackForDocument:(NSString *)documentId label:(NSString *)label value:(NSString *)value boundingBox:(NSDictionary *)boundingBox;
+- (BFTask *)submitFeedbackForDocument:(NSString *)documentId
+                                label:(NSString *)label
+                                value:(NSString *)value
+                          boundingBox:(NSDictionary *)boundingBox;
 
 /**
 * Submit batch feedback for the document on multiple labels.
@@ -176,7 +319,8 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 *
 * @returns                  A `BFTask*`
 */
-- (BFTask *)submitBatchFeedbackForDocument:(NSString *)documentId feedback:(NSDictionary *)feedback;
+- (BFTask *)submitBatchFeedbackForDocument:(NSString *)documentId
+                                  feedback:(NSDictionary *)feedback;
 
 /**
  * Delete a specific feedback label for the document.
@@ -186,7 +330,8 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  *
  * @returns                 `BFTask*`
  */
-- (BFTask *)deleteFeedbackForDocument:(NSString *)documentId label:(NSString *)label;
+- (BFTask *)deleteFeedbackForDocument:(NSString *)documentId
+                                label:(NSString *)label;
 
 /**
  * Searches for documents containing the given words.
@@ -198,7 +343,27 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  *
  * @returns                 A `BFTask*` that will resolve to a NSDictionary containing documents found.
  */
-- (BFTask *)search:(NSString *)searchTerm limit:(NSUInteger)limit offset:(NSUInteger)offset docType:(NSString *)docType;
+- (BFTask *)search:(NSString *)searchTerm
+             limit:(NSUInteger)limit
+            offset:(NSUInteger)offset
+           docType:(NSString *)docType;
+
+/**
+ * Searches for documents containing the given words.
+ *
+ * @param searchTerm                    The search term(s) separated by space.
+ * @param limit                         The number of results per page.
+ * @param offset                        The start offset.
+ * @param docType                       Restrict the search to a specific doctype.
+ * @param cancellationToken             Cancellation token used to cancel the current task.
+ *
+ * @returns                             A `BFTask*` that will resolve to a NSDictionary containing documents found.
+ */
+- (BFTask *)search:(NSString *)searchTerm
+             limit:(NSUInteger)limit
+            offset:(NSUInteger)offset
+           docType:(NSString *)docType
+ cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Report an error for a specific document. If the processing result for a document was not satisfactory (e.g.
@@ -212,7 +377,9 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @param summary           A summary for the error.
  * @param description       A detailed description for the error.
  */
-- (BFTask *)reportErrorForDocument:(NSString *)documentId summary:(NSString *)summary description:(NSString *)description;
+- (BFTask *)reportErrorForDocument:(NSString *)documentId
+                           summary:(NSString *)summary
+                       description:(NSString *)description;
 
 /**
  * The designated initializer.
@@ -224,6 +391,8 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @param baseURL           The baseURL. The requests to the Gini API are relative to that URL, so it usually should be
  *                          set to a `NSURL*` pointing to 'https://api.gini.net'.
  */
-- (instancetype)initWithURLSession:(id<GINIURLSession>)urlSession requestFactory:(id <GINIAPIManagerRequestFactory>)requestFactory baseURL:(NSURL *)baseURL;
+- (instancetype)initWithURLSession:(id<GINIURLSession>)urlSession
+                    requestFactory:(id <GINIAPIManagerRequestFactory>)requestFactory
+                           baseURL:(NSURL *)baseURL;
 
 @end

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -43,7 +43,9 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 }
 
 #pragma mark - Initializer
-- (instancetype)initWithURLSession:(id <GINIURLSession>)urlSession requestFactory:(id <GINIAPIManagerRequestFactory>)requestFactory baseURL:(NSURL *)baseURL {
+- (instancetype)initWithURLSession:(id <GINIURLSession>)urlSession
+                    requestFactory:(id <GINIAPIManagerRequestFactory>)requestFactory
+                           baseURL:(NSURL *)baseURL {
     NSParameterAssert([requestFactory conformsToProtocol:@protocol(GINIAPIManagerRequestFactory)]);
     NSParameterAssert([baseURL isKindOfClass:[NSURL class]]);
     NSParameterAssert([urlSession conformsToProtocol:@protocol(GINIURLSession)]);
@@ -58,19 +60,31 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 }
 
 #pragma mark - Public methods
-+ (instancetype)apiManagerWithURLSession:(id <GINIURLSession>)urlSession requestFactory:(id <GINIAPIManagerRequestFactory>)requestFactory baseURL:(NSURL *)baseURL {
++ (instancetype)apiManagerWithURLSession:(id <GINIURLSession>)urlSession
+                          requestFactory:(id <GINIAPIManagerRequestFactory>)requestFactory
+                                 baseURL:(NSURL *)baseURL {
     return [[self alloc] initWithURLSession:urlSession requestFactory:requestFactory baseURL:baseURL];
 }
 
 - (BFTask *)getDocument:(NSString *)documentId{
-    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    return [self getDocument:documentId cancellationToken:nil];
+}
 
+-(BFTask *)getDocument:(NSString *)documentId
+     cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"documents/%@", documentId]
                         relativeToURL:_baseURL];
-    return [self getDocumentWithURL:url];
+    return [self getDocumentWithURL:url cancellationToken:cancellationToken];
 }
 
 - (BFTask *)getDocumentWithURL:(NSURL *)location{
+    return [self getDocumentWithURL:location cancellationToken:nil];
+}
+
+-(BFTask *)getDocumentWithURL:(NSURL *)location
+            cancellationToken:(BFCancellationToken *)cancellationToken {
     return [[_requestFactory asynchronousRequestUrl:location withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
         [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Accept"];
@@ -78,13 +92,22 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = documentTask.result;
             return response.data;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
-- (BFTask *)getPreviewForPage:(NSUInteger)pageNumber ofDocument:(NSString *)documentId withSize:(GiniApiPreviewSize)size {
+- (BFTask *)getPreviewForPage:(NSUInteger)pageNumber
+                   ofDocument:(NSString *)documentId
+                     withSize:(GiniApiPreviewSize)size {
+    return [self getPreviewForPage:pageNumber ofDocument:documentId withSize:size cancellationToken:nil];
+}
+
+-(BFTask *)getPreviewForPage:(NSUInteger)pageNumber
+                  ofDocument:(NSString *)documentId
+                    withSize:(GiniApiPreviewSize)size
+           cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert(pageNumber > 0);
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
-
+    
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"documents/%@/pages/%lu/%@", documentId, (unsigned long)pageNumber, GINIPreviewSizeString(size)]
                         relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
@@ -96,10 +119,15 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             UIImage *image = [UIImage imageWithData:imageData];
             return image;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
 - (BFTask *)getPagesForDocument:(NSString *)documentId {
+    return [self getPagesForDocument:documentId cancellationToken:nil];
+}
+
+-(BFTask *)getPagesForDocument:(NSString *)documentId
+             cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
     
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"documents/%@/pages", documentId] relativeToURL:_baseURL];
@@ -110,12 +138,19 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = pagesTask.result;
             return response.data;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
-- (BFTask *)getLayoutForDocument:(NSString *)documentId responseType:(GiniAPIResponseType)responseType {
-    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+- (BFTask *)getLayoutForDocument:(NSString *)documentId
+                    responseType:(GiniAPIResponseType)responseType {
+    return [self getLayoutForDocument:documentId responseType:responseType cancellationToken: nil];
+}
 
+-(BFTask *)getLayoutForDocument:(NSString *)documentId
+                   responseType:(GiniAPIResponseType)responseType
+              cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"documents/%@/layout", documentId] relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
@@ -128,20 +163,31 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = layoutTask.result;
             return response.data;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
 
-- (BFTask *)uploadDocumentWithData:(NSData *)documentData contentType:(NSString *)contentType fileName:(NSString *)fileName docType:(NSString *)docType {
+- (BFTask *)uploadDocumentWithData:(NSData *)documentData
+                       contentType:(NSString *)contentType
+                          fileName:(NSString *)fileName
+                           docType:(NSString *)docType {
+    return [self uploadDocumentWithData:documentData contentType:contentType fileName:fileName docType:docType cancellationToken:nil];
+}
+
+- (BFTask *)uploadDocumentWithData:(NSData *)documentData
+                       contentType:(NSString *)contentType
+                          fileName:(NSString *)fileName
+                           docType:(NSString *)docType
+                 cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([documentData isKindOfClass:[NSData class]]);
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([contentType isKindOfClass:[NSString class]]);
-
+    
     NSString *urlString = [NSString stringWithFormat:@"documents/?filename=%@", stringByEscapingString(fileName)];
     if (docType) {
         urlString = [urlString stringByAppendingString:[NSString stringWithFormat:@"&doctype=%@", stringByEscapingString(docType)]];
     }
-
+    
     NSURL *url = [NSURL URLWithString:urlString relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"POST"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
@@ -152,12 +198,18 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = uploadTask.result;
             NSString *location = [[response.response allHeaderFields] valueForKey:@"Location"];
             // Get the document.
-            return [self getDocumentWithURL:[NSURL URLWithString:location]];
+            return [self getDocumentWithURL:[NSURL URLWithString:location] cancellationToken:cancellationToken];
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
+
 - (BFTask *)deleteDocument:(NSString *)documentId {
+    return [self deleteDocument:documentId cancellationToken:nil];
+}
+
+-(BFTask *)deleteDocument:(NSString *)documentId
+        cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
     
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"documents/%@", documentId] relativeToURL:_baseURL];
@@ -167,10 +219,17 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = documentTask.result;
             return response.data;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
-- (BFTask *)getDocumentsWithLimit:(NSUInteger)limit offset:(NSUInteger)offset {
+- (BFTask *)getDocumentsWithLimit:(NSUInteger)limit
+                           offset:(NSUInteger)offset {
+    return [self getDocumentsWithLimit:limit offset:offset cancellationToken:nil];
+}
+
+-(BFTask *)getDocumentsWithLimit:(NSUInteger)limit
+                          offset:(NSUInteger)offset
+               cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert(limit > 0);
     NSParameterAssert(offset >= 0);
     
@@ -183,18 +242,30 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = documentsTask.result;
             return response.data;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
 - (BFTask *)getExtractionsForDocument:(NSString *)documentId {
-    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.v1+json"];
+    return [self getExtractionsForDocument:documentId cancellationToken:nil];
+}
+
+- (BFTask *)getExtractionsForDocument:(NSString *)documentId
+                    cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.v1+json" cancellationToken:cancellationToken];
 }
 
 - (BFTask *)getIncubatorExtractionsForDocument:(NSString *)documentId {
-    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.incubator+json"];
+    return [self getIncubatorExtractionsForDocument:documentId cancellationToken:nil];
 }
 
-- (BFTask *)getExtractionsForDocument:(NSString *)documentId withHeader:(NSString *)header{
+-(BFTask *)getIncubatorExtractionsForDocument:(NSString *)documentId
+                            cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.incubator+json" cancellationToken:cancellationToken];
+}
+
+- (BFTask *)getExtractionsForDocument:(NSString *)documentId
+                           withHeader:(NSString *)header
+                    cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
 
     NSString *urlString = [NSString stringWithFormat:@"documents/%@/extractions", documentId];
@@ -206,10 +277,13 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = extractionsTask.result;
             return response.data;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
-- (BFTask *)submitFeedbackForDocument:(NSString *)documentId label:(NSString *)label value:(NSString *)value boundingBox:(NSDictionary *)boundingBox {
+- (BFTask *)submitFeedbackForDocument:(NSString *)documentId
+                                label:(NSString *)label
+                                value:(NSString *)value
+                          boundingBox:(NSDictionary *)boundingBox {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
     NSParameterAssert([label isKindOfClass:[NSString class]]);
     NSParameterAssert([value isKindOfClass:[NSString class]]);
@@ -231,7 +305,8 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     }];
 }
 
-- (BFTask *)submitBatchFeedbackForDocument:(NSString *)documentId feedback:(NSDictionary *)feedback {
+- (BFTask *)submitBatchFeedbackForDocument:(NSString *)documentId
+                                  feedback:(NSDictionary *)feedback {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
     NSParameterAssert([feedback isKindOfClass:[NSDictionary class]]);
 
@@ -252,7 +327,8 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     }];
 }
 
-- (BFTask *)deleteFeedbackForDocument:(NSString *)documentId label:(NSString *)label {
+- (BFTask *)deleteFeedbackForDocument:(NSString *)documentId
+                                label:(NSString *)label {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
     NSParameterAssert([label isKindOfClass:[NSString class]]);
     
@@ -268,7 +344,18 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     }];
 }
 
-- (BFTask *)search:(NSString *)searchTerm limit:(NSUInteger)limit offset:(NSUInteger)offset docType:(NSString *)docType {
+- (BFTask *)search:(NSString *)searchTerm
+             limit:(NSUInteger)limit
+            offset:(NSUInteger)offset
+           docType:(NSString *)docType {
+    return [self search:searchTerm limit:limit offset:offset docType:docType cancellationToken:nil];
+}
+
+- (BFTask *)search:(NSString *)searchTerm
+             limit:(NSUInteger)limit
+            offset:(NSUInteger)offset
+           docType:(NSString *)docType
+ cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([searchTerm isKindOfClass:[NSString class]]);
     
     NSString *urlString = [NSString stringWithFormat:@"search?q=%@&limit=%lu&offset=%lu&docType=%@", searchTerm, (unsigned long)limit, (unsigned long)offset, docType];
@@ -281,10 +368,12 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             GINIURLResponse *response = searchTask.result;
             return response.data;
         }];
-    }];
+    } cancellationToken:cancellationToken];
 }
 
-- (BFTask *)reportErrorForDocument:(NSString *)documentId summary:(NSString *)summary description:(NSString *)description {
+- (BFTask *)reportErrorForDocument:(NSString *)documentId
+                           summary:(NSString *)summary
+                       description:(NSString *)description {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
 
     NSString *summaryEncoded = stringByEscapingString(summary);

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -146,6 +146,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"POST"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
         [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
+        
         return [[self->_urlSession BFUploadTaskWithRequest:requestTask.result fromData:documentData] continueWithSuccessBlock:^id(BFTask *uploadTask) {
             // The HTTP response has a Location header with the URL of the document.
             GINIURLResponse *response = uploadTask.result;

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -112,6 +112,12 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 /**
  * Gets the extractions from the document.
  *
+ */
+- (BFTask *)getExtractions;
+
+/**
+ * Gets the extractions from the document.
+ *
  * @param cancellationToken     Cancellation token used to cancel the current task.
  *
  */
@@ -120,10 +126,22 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 /**
  * Gets the candidates from the document.
  *
+ */
+- (BFTask *)getCandidates;
+
+/**
+ * Gets the candidates from the document.
+ *
  * @param cancellationToken     Cancellation token used to cancel the current task.
  *
  */
 - (BFTask *)getCandidatesWithCancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Gets the layout from the document.
+ *
+ */
+- (BFTask *)getLayout;
 
 /**
  * Gets the layout from the document.

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -79,7 +79,11 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  * @param documentManager       The document manager that is used to get the additional data, e.g. for the `extractions`
  *                              and `layout` property.
  */
-- (instancetype)initWithId:(NSString *)documentId state:(GiniDocumentState)state pageCount:(NSUInteger)pageCount sourceClassification:(GiniDocumentSourceClassification)sourceClassification documentManager:(GINIDocumentTaskManager *)documentManager;
+- (instancetype)initWithId:(NSString *)documentId
+                     state:(GiniDocumentState)state
+                 pageCount:(NSUInteger)pageCount
+      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
+           documentManager:(GINIDocumentTaskManager *)documentManager;
 
 /**
  * Gets the preview image for the given page.
@@ -91,4 +95,41 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  *                          document are processed by the Gini API.
  */
 - (BFTask *)previewWithSize:(GiniApiPreviewSize)size forPage:(NSUInteger)page;
+
+/**
+ * Gets the preview image for the given page.
+ *
+ * @param size                  The size of the rendered preview. Please notice that those sizes are the maximum sizes of the
+ *                              renderings, the actual image can have smaller dimensions.
+ * @param page                  The page for which the preview is rendered. Please notice that only the first 10 pages of a
+ *                              document are processed by the Gini API.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ */
+- (BFTask *)previewWithSize:(GiniApiPreviewSize)size forPage:(NSUInteger)page
+          cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Gets the extractions from the document.
+ *
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ */
+- (BFTask *)getExtractionsWithCancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Gets the candidates from the document.
+ *
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ */
+- (BFTask *)getCandidatesWithCancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Gets the layout from the document.
+ *
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ */
+- (BFTask *)getLayoutWithCancellationToken:(BFCancellationToken *)cancellationToken;
 @end

--- a/Gini-iOS-SDK/GINIDocument.m
+++ b/Gini-iOS-SDK/GINIDocument.m
@@ -95,6 +95,10 @@
                                  cancellationToken:cancellationToken];
 }
 
+- (BFTask *)getExtractions {
+    return [self getExtractionsWithCancellationToken:nil];
+}
+
 - (BFTask *)getExtractionsWithCancellationToken:(BFCancellationToken *)cancellationToken {
     return [[self extractionTaskWithCancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         NSMutableDictionary *results = task.result;
@@ -102,11 +106,19 @@
     }];
 }
 
+- (BFTask *)getCandidates {
+    return [self getCandidatesWithCancellationToken:nil];
+}
+
 -(BFTask *)getCandidatesWithCancellationToken:(BFCancellationToken *)cancellationToken {
     return [[self extractionTaskWithCancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         NSDictionary *results = task.result;
         return [results valueForKey:@"candidates"];
     }];
+}
+
+- (BFTask *)getLayout {
+    return [self getLayoutWithCancellationToken:nil];
 }
 
 - (BFTask *)getLayoutWithCancellationToken:(BFCancellationToken *)cancellationToken {
@@ -131,15 +143,15 @@
 }
 
 - (BFTask *)extractions {
-    return [self getExtractionsWithCancellationToken:nil];
+    return [self getExtractions];
 }
 
 - (BFTask *)candidates {
-    return [self getCandidatesWithCancellationToken:nil];
+    return [self getCandidates];
 }
 
 - (BFTask *)layout {
-    return [self getLayoutWithCancellationToken:nil];
+    return [self getLayout];
 }
 
 - (NSString *)description {

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -55,6 +55,17 @@
 - (BFTask *)getDocumentWithId:(NSString *)documentId;
 
 /**
+ * Gets the document with the given id.
+ *
+ * @param documentId            The document's unique identifier.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
+ */
+- (BFTask *)getDocumentWithId:(NSString *)documentId
+            cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
  * Creates a new document from the given image.
  *
  * @param fileName      The file name of the document.
@@ -64,7 +75,23 @@
  *                      Please notice that it is very unlikely that the created document is already fully processed, so
  *                      the extractions may not yet exist.
  */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image;
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image;
+
+/**
+ * Creates a new document from the given image.
+ *
+ * @param fileName              The file name of the document.
+ * @param image                 An image representing the document.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                              Please notice that it is very unlikely that the created document is already fully processed, so
+ *                              the extractions may not yet exist.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
@@ -76,7 +103,24 @@
  * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
  * knows the doctype.
  */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType;
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                               docType:(NSString *)docType;
+
+/**
+ * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
+ * processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
+ * knows the doctype.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                               docType:(NSString *)docType
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Creates a new document with the given `doctype` from the given data. 
@@ -94,7 +138,31 @@
  *                      Please notice that it is very unlikely that the created document is already fully processed, so
  *                      the extractions may not yet exist.
  */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType;
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType;
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @param fileName                  The file name of the document.
+ * @param data                      Data representing the document.
+ * @param docType                   The doctype hint for the document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ *
+ * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                                  Please notice that it is very unlikely that the created document is already fully processed, so
+ *                                  the extractions may not yet exist.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Saves updates on the extractions.
@@ -106,11 +174,31 @@
 - (BFTask *)updateDocument:(GINIDocument *)document;
 
 /**
+ * Saves updates on the extractions.
+ *
+ * Updating extractions is called "Submitting feedback" in the Gini API documentation.
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
+- (BFTask *)updateDocument:(GINIDocument *)document
+         cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
  * Deletes the given document.
  *
  * @param document      The document that will be deleted.
  */
 - (BFTask *)deleteDocument:(GINIDocument *)document;
+
+/**
+ * Deletes the given document.
+ *
+ * @param document                  The document that will be deleted.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
+- (BFTask *)deleteDocument:(GINIDocument *)document
+         cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Continually checks the document status until the document is fully processed.
@@ -130,6 +218,25 @@
 - (BFTask *)pollDocument:(GINIDocument *)document;
 
 /**
+ * Continually checks the document status until the document is fully processed.
+ *
+ * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+ * available.
+ *
+ * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+ * `pollingInterval` property of this class.
+ *
+ * @warning                         This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
+ *                                  document. Please notice that the task's result will not be the same document object as the given
+ *                                  document instance and the given document instance will not be updated with the polled results!
+ *
+ * @param document                  The document that will be polled.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
+- (BFTask *)pollDocument:(GINIDocument *)document
+       cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
 * Continually checks the document status until the document is fully processed.
 *
 * If the document is in the error state, this method also does not continue polling, but the extractions won't be
@@ -143,6 +250,21 @@
 - (BFTask *)pollDocumentWithId:(NSString *)documentId;
 
 /**
+ * Continually checks the document status until the document is fully processed.
+ *
+ * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+ * available.
+ *
+ * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+ * `pollingInterval` property of this class.
+ *
+ * @param documentId                The unique identifier of the document which will be polled.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
+- (BFTask *)pollDocumentWithId:(NSString *)documentId
+             cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
  * Gets the preview image for the given page of the given document.
  *
  * @param page          The page number of the document (starting from 1, not 0!).
@@ -151,7 +273,24 @@
  *                      meaning that the images dimensions will not exceeding this limit but the rendered image can
  *                      actually have a little smaller dimensions.
  */
-- (BFTask *)getPreviewForPage:(NSUInteger)page ofDocument:(GINIDocument *)document withSize:(GiniApiPreviewSize)size;
+- (BFTask *)getPreviewForPage:(NSUInteger)page
+                   ofDocument:(GINIDocument *)document
+                     withSize:(GiniApiPreviewSize)size;
+
+/**
+ * Gets the preview image for the given page of the given document.
+ *
+ * @param page                      The page number of the document (starting from 1, not 0!).
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ * @param size                      The size in which the document will be rendered. Please notice that this is the maximum size,
+ *                                  meaning that the images dimensions will not exceeding this limit but the rendered image can
+ *                                  actually have a little smaller dimensions.
+ */
+- (BFTask *)getPreviewForPage:(NSUInteger)page
+                   ofDocument:(GINIDocument *)document
+                     withSize:(GiniApiPreviewSize)size
+            cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Gets the extractions for the given document.
@@ -161,12 +300,31 @@
 - (BFTask *)getExtractionsForDocument:(GINIDocument *)document;
 
 /**
+ * Gets the extractions for the given document.
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
+- (BFTask *)getExtractionsForDocument:(GINIDocument *)document
+                    cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
 * Gets the extractions for the specific document, including the incubation extractions (see
 * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
 *
 * @param document       The document.
 */
 - (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document;
+
+/**
+ * Gets the extractions for the specific document, including the incubation extractions (see
+ * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
+- (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document
+                             cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Saves the new values for the given extraction of the given document.
@@ -186,6 +344,15 @@
 - (BFTask *)getLayoutForDocument:(GINIDocument *)document;
 
 /**
+ * Gets the layout for the given document.
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
+- (BFTask *)getLayoutForDocument:(GINIDocument *)document
+               cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
  * Report an error for a specific document. If the processing result for a document was not satisfactory (e.g.
  * extractions where empty or incorrect), you can create an error report for a document. This allows Gini to analyze and
  * correct the problem that was found. The returned errorId can be used to refer to the reported error towards the Gini
@@ -197,5 +364,7 @@
  * @param summary           A summary for the error (optional).
  * @param description       A detailed description for the error (optional).
  */
-- (BFTask *)errorReportForDocument:(GINIDocument *)document summary:(NSString *)summary description:(NSString *)description;
+- (BFTask *)errorReportForDocument:(GINIDocument *)document
+                           summary:(NSString *)summary
+                       description:(NSString *)description;
 @end

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -62,9 +62,13 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 
 #pragma mark - Document methods
 - (BFTask *)getDocumentWithId:(NSString *)documentId{
-    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    return [self getDocumentWithId:documentId cancellationToken:nil];
+}
 
-    BFTask *documentTask = [[_apiManager getDocument:documentId] continueWithSuccessBlock:^id(BFTask *task) {
+- (BFTask *)getDocumentWithId:(NSString *)documentId cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    
+    BFTask *documentTask = [[_apiManager getDocument:documentId cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         GINIDocument *document = [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
         return document;
     }];
@@ -72,27 +76,47 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image {
-    return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:nil];
+    return [self createDocumentWithFilename:fileName fromImage:image cancellationToken:nil];
+}
+
+-(BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:nil cancellationToken:cancellationToken];
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType {
-    return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:docType];
+    return [self createDocumentWithFilename:fileName fromImage:image docType:docType cancellationToken:nil];
+}
+
+-(BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:docType cancellationToken:cancellationToken];
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType {
+    return [self createDocumentWithFilename:fileName fromData:data docType:docType cancellationToken:nil];
+}
+
+-(BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([data isKindOfClass:[NSData class]]);
     
-    BFTask *createTask = [[_apiManager uploadDocumentWithData:data contentType:@"image/jpeg" fileName:fileName docType:docType] continueWithSuccessBlock:^id(BFTask *task) {
+    BFTask *createTask = [[_apiManager uploadDocumentWithData:data
+                                                  contentType:@"image/jpeg"
+                                                     fileName:fileName
+                                                      docType:docType
+                                            cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
     }];
     return GINIhandleHTTPerrors(createTask);
 }
 
 - (BFTask *)updateDocument:(GINIDocument *)document {
+    return [self updateDocument:document cancellationToken:nil];
+}
+
+-(BFTask *)updateDocument:(GINIDocument *)document cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
     
-    BFTask *updateTask = [document.extractions continueWithSuccessBlock:^id(BFTask *task) {
+    BFTask *updateTask = [[document getExtractionsWithCancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         NSDictionary *extractions = task.result;
         NSMutableDictionary *updateExtractions = [NSMutableDictionary new];
         
@@ -110,36 +134,54 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 }
 
 - (BFTask *)deleteDocument:(GINIDocument *)document {
-    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    return [self deleteDocument:document cancellationToken:nil];
+}
 
-    return GINIhandleHTTPerrors([_apiManager deleteDocument:document.documentId]);
+- (BFTask *)deleteDocument:(GINIDocument *)document
+         cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    
+    return GINIhandleHTTPerrors([_apiManager deleteDocument:document.documentId cancellationToken:cancellationToken]);
 }
 
 - (BFTask *)pollDocument:(GINIDocument *)document {
-    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    return [self pollDocument:document cancellationToken:nil];
+}
 
+- (BFTask *)pollDocument:(GINIDocument *)document
+       cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    
     // Immediately return already processed documents.
     if (document.state == GiniDocumentStateComplete) {
         return [BFTask taskWithResult:document];
     }
-
-    return [self pollDocumentWithId:document.documentId];
+    
+    return [self pollDocumentWithId:document.documentId
+                  cancellationToken:cancellationToken];
 }
 
 - (BFTask *)pollDocumentWithId:(NSString *)documentId{
-    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    return [self pollDocumentWithId:documentId cancellationToken:nil];
+}
 
-    BFTask *pollTask = [self privatePollDocumentWithId:documentId];
+- (BFTask *)pollDocumentWithId:(NSString *)documentId
+             cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    
+    BFTask *pollTask = [self privatePollDocumentWithId:documentId cancellationToken:cancellationToken];
     return GINIhandleHTTPerrors(pollTask);
 }
 
-- (BFTask *)privatePollDocumentWithId:(NSString *)documentId {
-    return [[_apiManager getDocument:documentId] continueWithSuccessBlock:^id(BFTask *task) {
+
+- (BFTask *)privatePollDocumentWithId:(NSString *)documentId
+                    cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [[_apiManager getDocument:documentId cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         NSDictionary *polledDocument = task.result;
         // If the document is not fully processed yet, wait a second and then poll again.
         if ([polledDocument[@"progress"] isEqualToString:@"PENDING"]) {
-            return [[BFTask taskWithDelay:(int)self.pollingInterval * 1000] continueWithSuccessBlock:^id(BFTask *waitTask) {
-                return [self privatePollDocumentWithId:documentId];
+            return [[BFTask taskWithDelay:(int)self.pollingInterval * 1000 cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *waitTask) {
+                return [self privatePollDocumentWithId:documentId cancellationToken:cancellationToken];
             }];
             // Otherwise return the document.
         } else {
@@ -148,26 +190,47 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     }];
 }
 
-- (BFTask *)getPreviewForPage:(NSUInteger)page ofDocument:(GINIDocument *)document withSize:(GiniApiPreviewSize)size {
+- (BFTask *)getPreviewForPage:(NSUInteger)page
+                   ofDocument:(GINIDocument *)document
+                     withSize:(GiniApiPreviewSize)size {
+    return [self getPreviewForPage:page ofDocument:document withSize:size cancellationToken:nil];
+}
+
+- (BFTask *)getPreviewForPage:(NSUInteger)page
+                   ofDocument:(GINIDocument *)document
+                     withSize:(GiniApiPreviewSize)size
+            cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert(page > 0);
     NSParameterAssert(page <= document.pageCount);
-
-    BFTask *pageTask = [_apiManager getPreviewForPage:page ofDocument:document.documentId withSize:size];
+    
+    BFTask *pageTask = [_apiManager getPreviewForPage:page ofDocument:document.documentId withSize:size cancellationToken:cancellationToken];
     return GINIhandleHTTPerrors(pageTask);
 }
 
 #pragma mark - Extraction methods
 - (BFTask *)getExtractionsForDocument:(GINIDocument *)document {
-    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    return [self getExtractionsForDocument:document cancellationToken:nil];
+}
 
-    BFTask *extractionsTask = [self createExtractionsForGetTask:[_apiManager getExtractionsForDocument:document.documentId]];
+- (BFTask *)getExtractionsForDocument:(GINIDocument *)document
+                    cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    
+    BFTask *extractionsTask = [self createExtractionsForGetTask:[_apiManager getExtractionsForDocument:document.documentId
+                                                                                     cancellationToken:cancellationToken]];
     return GINIhandleHTTPerrors(extractionsTask);
 }
 
 - (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document {
-    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    return [self getIncubatorExtractionsForDocument:document cancellationToken:nil];
+}
 
-    BFTask *extractionsTask = [self createExtractionsForGetTask:[_apiManager getIncubatorExtractionsForDocument:document.documentId]];
+- (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document
+                             cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    
+    BFTask *extractionsTask = [self createExtractionsForGetTask:[_apiManager getIncubatorExtractionsForDocument:document.documentId
+                                                                                              cancellationToken:cancellationToken]];
     return GINIhandleHTTPerrors(extractionsTask);
 }
 
@@ -238,13 +301,19 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 }
 
 - (BFTask *)getLayoutForDocument:(GINIDocument *)document {
-    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    return [self getLayoutForDocument:document cancellationToken:nil];
+}
 
+- (BFTask *)getLayoutForDocument:(GINIDocument *)document cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
+    
     BFTask *layoutTask = [_apiManager getLayoutForDocument:document.documentId responseType:(GiniAPIResponseTypeJSON)];
     return GINIhandleHTTPerrors(layoutTask);
 }
 
-- (BFTask *)errorReportForDocument:(GINIDocument *)document summary:(NSString *)summary description:(NSString *)description{
+- (BFTask *)errorReportForDocument:(GINIDocument *)document
+                           summary:(NSString *)summary
+                       description:(NSString *)description{
     NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
 
     BFTask *errorReportTask = [_apiManager reportErrorForDocument:document.documentId summary:summary description:description];

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -79,7 +79,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return [self createDocumentWithFilename:fileName fromImage:image cancellationToken:nil];
 }
 
--(BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image cancellationToken:(BFCancellationToken *)cancellationToken {
     return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:nil cancellationToken:cancellationToken];
 }
 
@@ -87,7 +87,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return [self createDocumentWithFilename:fileName fromImage:image docType:docType cancellationToken:nil];
 }
 
--(BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
     return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:docType cancellationToken:cancellationToken];
 }
 
@@ -95,7 +95,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return [self createDocumentWithFilename:fileName fromData:data docType:docType cancellationToken:nil];
 }
 
--(BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([data isKindOfClass:[NSData class]]);
     
@@ -113,7 +113,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return [self updateDocument:document cancellationToken:nil];
 }
 
--(BFTask *)updateDocument:(GINIDocument *)document cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)updateDocument:(GINIDocument *)document cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
     
     BFTask *updateTask = [[document getExtractionsWithCancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {

--- a/Gini-iOS-SDK/GINISessionManagerAnonymous.m
+++ b/Gini-iOS-SDK/GINISessionManagerAnonymous.m
@@ -181,8 +181,6 @@ NSString *const GINIUsingExistingUserNotification = @"UsingExistingUserNotificat
     return [[_userCenterManager createUserWithEmail:email password:password] continueWithBlock:^id(BFTask *task) {
         if (task.error) {
             return [BFTask taskWithError:[GINIError errorWithCode:GINIErrorUserCreationError cause:task.error userInfo:nil]];
-        } else if (task.exception) {
-            return task;
         }
         [self->_credentialsStore storeUserCredentials:email password:password];
         return nil;

--- a/Gini-iOS-SDK/GINISessionManagerServerFlow.m
+++ b/Gini-iOS-SDK/GINISessionManagerServerFlow.m
@@ -135,10 +135,7 @@ NSString *const GINIServerFlowResponseType = @"code";
             if (code) {
                 [_activeLogInTask setResult:code];
             }
-            else {
-                // TODO: Add no code found error
-                [_activeLogInTask setError:nil];
-            }
+            
             _activeLogInTask = nil;
             _activeLogInState = nil;
             return YES;

--- a/Gini-iOS-SDK/GINIUserCenterManager.m
+++ b/Gini-iOS-SDK/GINIUserCenterManager.m
@@ -100,7 +100,7 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
             return serializationError;
         }
         return [[self->_urlSession BFDataTaskWithRequest:urlRequest] continueWithBlock:^id(BFTask *createTask) {
-            if (createTask.error || createTask.exception) {
+            if (createTask.error) {
                 [self->_notificationCenter postNotificationName:GINIUserCreationErrorNotification object:nil];
                 return createTask;
             }
@@ -141,7 +141,7 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
         }
 
         // Pass-through all other errors.
-        if (loginTask.error || loginTask.exception) {
+        if (loginTask.error) {
             // TODO (maybe discriminable notifications)
             [self->_notificationCenter postNotificationName:GINILoginErrorNotification object:nil];
             return loginTask;

--- a/Gini-iOS-SDKTests/GINIUserCenterManagerSpec.m
+++ b/Gini-iOS-SDKTests/GINIUserCenterManagerSpec.m
@@ -17,470 +17,498 @@
 
 SPEC_BEGIN(GINIUserCenterManagerSpec)
 
-    describe(@"The GINIUserCenterManager", ^{
-
-        /* The `GINIUserCenterManager` instance that is tested in the tests */
-        __block GINIUserCenterManager *userCenterManager;
-        /** The `GINIURLSession` instance used in the tests as the dependency of the userCenterManager. */
-        __block GINIURLSessionMock *urlSession;
-        /** The mock for NSNotificationCenter which is used in the tests as the dependency of the userCenterManager */
-        __block GININSNotificationCenterMock *notificationCenter;
-
-        /**
-         * Helper function which checks that the last request the GINIURLSessionMock received was to the correct URL and
-         * used the correct HTTP method.
-         */
-        __block void (^checkRequest)(NSString *URL, NSString *httpMethod) = ^(NSString *URL, NSString *httpMethod) {
-            // Check for the correct URL.
-            NSURLRequest *request = urlSession.lastRequest;
-            [[request shouldNot] beNil];
-            [[[[request URL] absoluteString] should] equal:URL];
-            [[request.HTTPMethod should] equal:httpMethod];
-        };
-
-        /**
-         * Helper function which checks that the last request the GINIURLSessionMock received had an authorization
-         * header with the correct bearer token (The token is from the fake server reply, see code below in the
-         * beforeEach block).
-         */
-        __block void (^checkAccessToken)() = ^() {
-            NSURLRequest *request = urlSession.lastRequest;
-            [[request shouldNot] beNil];
-            [[request.allHTTPHeaderFields[@"Authorization"] should] equal:@"BEARER 1234-5678"];
-        };
-
-        /**
-         * Helper function which checks that the last request the GINIURLSessionMock received had an authorization
-         * header with the correct HTTP basic authorization.
-         */
-        __block void (^checkBasicAuthentication)() = ^() {
-            NSURLRequest *request = urlSession.lastRequest;
-            [[request shouldNot] beNil];
-            [[request.allHTTPHeaderFields[@"Authorization"] should] equal:@"Basic Zm9vOmJhcg=="];
-        };
+describe(@"The GINIUserCenterManager", ^{
+    
+    /* The `GINIUserCenterManager` instance that is tested in the tests */
+    __block GINIUserCenterManager *userCenterManager;
+    /** The `GINIURLSession` instance used in the tests as the dependency of the userCenterManager. */
+    __block GINIURLSessionMock *urlSession;
+    /** The mock for NSNotificationCenter which is used in the tests as the dependency of the userCenterManager */
+    __block GININSNotificationCenterMock *notificationCenter;
+    
+    /**
+     * Helper function which checks that the last request the GINIURLSessionMock received was to the correct URL and
+     * used the correct HTTP method.
+     */
+    __block void (^checkRequest)(NSString *URL, NSString *httpMethod) = ^(NSString *URL, NSString *httpMethod) {
+        // Check for the correct URL.
+        NSURLRequest *request = urlSession.lastRequest;
+        [[request shouldNot] beNil];
+        [[[[request URL] absoluteString] should] equal:URL];
+        [[request.HTTPMethod should] equal:httpMethod];
+    };
+    
+    /**
+     * Helper function which checks that the last request the GINIURLSessionMock received had an authorization
+     * header with the correct bearer token (The token is from the fake server reply, see code below in the
+     * beforeEach block).
+     */
+    __block void (^checkAccessToken)() = ^() {
+        NSURLRequest *request = urlSession.lastRequest;
+        [[request shouldNot] beNil];
+        [[request.allHTTPHeaderFields[@"Authorization"] should] equal:@"BEARER 1234-5678"];
+    };
+    
+    /**
+     * Helper function which checks that the last request the GINIURLSessionMock received had an authorization
+     * header with the correct HTTP basic authorization.
+     */
+    __block void (^checkBasicAuthentication)() = ^() {
+        NSURLRequest *request = urlSession.lastRequest;
+        [[request shouldNot] beNil];
+        [[request.allHTTPHeaderFields[@"Authorization"] should] equal:@"Basic Zm9vOmJhcg=="];
+    };
+    
+    __block NSString *(^setResponsesForUpdateEmail)(GINISession *) = ^(GINISession *session) {
+        NSString *tokenInfoUrl = [NSString stringWithFormat:@"https://user.gini.net/oauth/check_token?token=%@", session.accessToken];
         
-        __block NSString *(^setResponsesForUpdateEmail)(GINISession *) = ^(GINISession *session) {
-            NSString *tokenInfoUrl = [NSString stringWithFormat:@"https://user.gini.net/oauth/check_token?token=%@", session.accessToken];
+        NSURL *tokenInfoResponseURL = [NSURL URLWithString:tokenInfoUrl];
+        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:tokenInfoResponseURL
+                                                                  statusCode:201
+                                                                 HTTPVersion:@"1.1"
+                                                                headerFields:nil];
+        
+        NSString *userId = @"JohnDoe";
+        GINIURLResponse *tokenInfoResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
+                                                                                                      @"user_name": userId
+                                                                                                      }];
+        [urlSession setResponse:[BFTask taskWithResult:tokenInfoResponse] forURL:tokenInfoUrl];
+        
+        NSString *url = [NSString stringWithFormat:@"https://user.gini.net/api/users/%@", userId];
+        [urlSession setResponse:[BFTask taskWithError:nil] forURL:url];
+        return url;
+        
+    };
+    
+    beforeEach(^{
+        urlSession = [GINIURLSessionMock new];
+        notificationCenter = [GININSNotificationCenterMock defaultCenter];
+        userCenterManager = [GINIUserCenterManager userCenterManagerWithURLSession:urlSession
+                                                                          clientID:@"foo"
+                                                                      clientSecret:@"bar"
+                                                                           baseURL:[NSURL URLWithString:@"https://user.gini.net/"]
+                                                                notificationCenter:notificationCenter];
+        
+        // Set the response for an authorization request, so the tests can receive an access token and can create
+        // a `GINISession` instance.
+        NSDictionary *sessionResponse = @{
+                                          @"access_token": @"1234-5678",
+                                          @"expires_in": @5000,
+                                          @"token_type": @"bearer"
+                                          };
+        [urlSession createAndSetResponse:sessionResponse httpStatus:0 forURL:@"https://user.gini.net/oauth/token?grant_type=client_credentials" error:NO];
+    });
+    
+    it(@"should raise an error if instantiated with the wrong dependencies", ^{
+        [[theBlock(^{
+            [GINIUserCenterManager userCenterManagerWithURLSession:nil clientID:nil clientSecret:nil baseURL:nil notificationCenter:nil];
+        }) should] raise];
+        
+        [[theBlock(^{
+            [GINIUserCenterManager userCenterManagerWithURLSession:nil clientID:nil clientSecret:@"foo" baseURL:nil notificationCenter:nil];
+        }) should] raise];
+        
+        [[theBlock(^{
+            [GINIUserCenterManager userCenterManagerWithURLSession:nil clientID:@"foo" clientSecret:@"bar" baseURL:nil notificationCenter:nil];
+        }) should] raise];
+    });
+    
+    it(@"should build the correct login header", ^{
+        // Base64 of "foo:bar" (client ID : client secret)
+        [[[userCenterManager createLoginHeader] should] equal:@"Basic Zm9vOmJhcg=="];
+    });
+    
+    context(@"the getUserInfo: method", ^{
+        it(@"should throw an error if getting the wrong arguments", ^{
+            [[theBlock(^{
+                [userCenterManager getUserInfo:nil];
+            }) should] raise];
+        });
+        
+        it(@"should do the HTTP request to the correct URL", ^{
+            [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
+            [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
+            checkRequest(@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406", @"GET");
+        });
+        
+        it(@"should set the correct access token", ^{
+            [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
+            [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
+            checkAccessToken();
+        });
+        
+        it(@"should return a BFTask instance", ^{
+            [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
+            BFTask *infoTask = [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
+            [[infoTask should] beKindOfClass:[BFTask class]];
+        });
+        
+        it(@"should return a task that resolves to a GINIUser instance", ^{
+            NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
+            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
+                                                                      statusCode:201
+                                                                     HTTPVersion:@"1.1"
+                                                                    headerFields:nil];
+            GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
+                                                                                                     @"id":    @"88a28076-18e8-4275-b39c-eaacc240d406",
+                                                                                                     @"email": @"foobar@example.com"
+                                                                                                     }];
+            [urlSession setResponse:[BFTask taskWithResult:giniResponse]
+                             forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
             
-            NSURL *tokenInfoResponseURL = [NSURL URLWithString:tokenInfoUrl];
-            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:tokenInfoResponseURL
+            BFTask *userTask = [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
+            [[userTask.result should] beKindOfClass:[GINIUser class]];
+            GINIUser *user = userTask.result;
+            [[user.userId should] equal:@"88a28076-18e8-4275-b39c-eaacc240d406"];
+            [[user.userEmail should] equal:@"foobar@example.com"];
+        });
+    });
+    
+    context(@"the createUserWithEmail:password: method", ^{
+        it(@"should throw an error if getting the wrong arguments", ^{
+            [[theBlock(^{
+                [userCenterManager createUserWithEmail:nil password:nil];
+            }) should] raise];
+            
+            [[theBlock(^{
+                [userCenterManager createUserWithEmail:@"foobar" password:nil];
+            }) should] raise];
+            
+        });
+        
+        it(@"should do the HTTP request to the correct URL", ^{
+            NSError* error = [[NSError alloc] init];
+            
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/api/users"];
+            [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            checkRequest(@"https://user.gini.net/api/users", @"POST");
+        });
+        
+        it(@"should set the correct access token", ^{
+            NSError* error = [[NSError alloc] init];
+            
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/api/users"];
+            [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            checkAccessToken();
+        });
+        
+        it(@"should submit the correct data", ^{
+            NSError* error = [[NSError alloc] init];
+            
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/api/users"];
+            [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            NSURLRequest *lastRequest = urlSession.lastRequest;
+            NSString *expectedData = @"{\"email\":\"foobar@example.com\",\"password\":\"1234\"}";
+            NSDictionary *expectedJSON = [NSJSONSerialization JSONObjectWithData:[expectedData dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil];
+            NSString *actualData = [[NSString alloc] initWithData:lastRequest.HTTPBody encoding:NSUTF8StringEncoding];
+            NSDictionary *actualJSON = [NSJSONSerialization JSONObjectWithData:[actualData dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil];
+            [[expectedJSON should] equal:actualJSON];
+        });
+        
+        it(@"should return a BFTask instance", ^{
+            NSError* error = [[NSError alloc] init];
+            
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/api/users"];
+            BFTask *createTask = [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            [[createTask should] beKindOfClass:[BFTask class]];
+        });
+        
+        it(@"should return a task that resolves to a GINIUser instance", ^{
+            NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/api/users"];
+            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
+                                                                      statusCode:201
+                                                                     HTTPVersion:@"1.1"
+                                                                    headerFields:@{
+                                                                                   @"Location": @"https://user.gini.net/api/users/c1e60c6b-a0a4-4d80-81eb-c1c6de729a0e"
+                                                                                   }];
+            GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response];
+            [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:@"https://user.gini.net/api/users"];
+            
+            BFTask *createTask = [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            [[createTask.result should] beKindOfClass:[GINIUser class]];
+            GINIUser *user = createTask.result;
+            [[user.userId should] equal:@"c1e60c6b-a0a4-4d80-81eb-c1c6de729a0e"];
+            [[user.userEmail should] equal:@"foobar@example.com"];
+        });
+        
+        it(@"should trigger a notification when the user was created", ^{
+            NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/api/users"];
+            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
+                                                                      statusCode:201
+                                                                     HTTPVersion:@"1.1"
+                                                                    headerFields:@{
+                                                                                   @"Location": @"https://user.gini.net/api/users/c1e60c6b-a0a4-4d80-81eb-c1c6de729a0e"
+                                                                                   }];
+            GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response];
+            [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:@"https://user.gini.net/api/users"];
+            
+            [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            
+            [[notificationCenter.lastNotification shouldNot] beNil];
+            [[notificationCenter.lastNotification.name should] equal:GINIUserCreationNotification];
+            [[notificationCenter.lastNotification.object should] beKindOfClass:[GINIUser class]];
+            GINIUser *user = notificationCenter.lastNotification.object;
+            [[user.userEmail should] equal:@"foobar@example.com"];
+        });
+        
+        it(@"should post a notification when there was an error", ^{
+            [urlSession createAndSetResponse:nil httpStatus:500 forURL:@"https://user.gini.net/api/users" error:YES];
+            
+            [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            
+            [[notificationCenter.lastNotification shouldNot] beNil];
+            [[notificationCenter.lastNotification.name should] equal:GINIUserCreationErrorNotification];
+        });
+        
+        it(@"should set the proper HTTP headers", ^{
+            NSError* error = [[NSError alloc] init];
+            
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/api/users"];
+            [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
+            NSURLRequest *lastRequest = urlSession.lastRequest;
+            [[[lastRequest valueForHTTPHeaderField:@"Content-Type"] should] equal:@"application/json"];
+            [[[lastRequest valueForHTTPHeaderField:@"Accept"] should] equal:@"application/json"];
+        });
+    });
+    
+    context(@"the loginUser:password: method", ^{
+        it(@"should throw an error if getting the wrong arguments", ^{
+            [[theBlock(^{
+                [userCenterManager createUserWithEmail:nil password:nil];
+            }) should] raise];
+            
+            [[theBlock(^{
+                [userCenterManager createUserWithEmail:@"foobar" password:nil];
+            }) should] raise];
+            
+        });
+        
+        it(@"should do the HTTP request to the correct URL", ^{
+            NSError* error = [[NSError alloc] init];
+            
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
+            [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
+            checkRequest(@"https://user.gini.net/oauth/token?grant_type=password", @"POST");
+        });
+        
+        it(@"should set the correct authentication headers", ^{
+            NSError* error = [[NSError alloc] init];
+            
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
+            [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
+            checkBasicAuthentication();
+        });
+        
+        it(@"should submit the correct data", ^{
+            NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/oauth/token?grant_type=password"];
+            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
+                                                                      statusCode:201
+                                                                     HTTPVersion:@"1.1"
+                                                                    headerFields:@{
+                                                                                   @"Location": @"https://user.gini.net/api/users/c1e60c6b-a0a4-4d80-81eb-c1c6de729a0e"
+                                                                                   }];
+            GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
+                                                                                                     @"access_token": @"6c470ffa-abf1-41aa-b866-cd3be0ee84f4",
+                                                                                                     @"token_type":   @"bearer",
+                                                                                                     @"expires_in":   @3599
+                                                                                                     }];
+            [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
+            [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
+            NSURLRequest *lastRequest = urlSession.lastRequest;
+            NSString *expectedData = @"username=foobar%40example.com&password=1234";
+            NSString *actualData = [[NSString alloc] initWithData:lastRequest.HTTPBody encoding:NSUTF8StringEncoding];
+            [[expectedData should] equal:actualData];
+        });
+        
+        it(@"should return a BFTask instance", ^{
+            NSError* error = [[NSError alloc] init];
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
+            BFTask *loginTask = [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
+            [[loginTask should] beKindOfClass:[BFTask class]];
+        });
+        
+        it(@"should return a BFTask instance that resolves to a GINISession instance", ^{
+            NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/oauth/token?grant_type=password"];
+            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
+                                                                      statusCode:201
+                                                                     HTTPVersion:@"1.1"
+                                                                    headerFields:nil];
+            GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
+                                                                                                     @"access_token": @"6c470ffa-abf1-41aa-b866-cd3be0ee84f4",
+                                                                                                     @"token_type":   @"bearer",
+                                                                                                     @"expires_in":   @3599
+                                                                                                     }];
+            [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
+            
+            BFTask *loginTask = [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
+            [[loginTask.result should] beKindOfClass:[GINISession class]];
+            GINISession *session = loginTask.result;
+            [[session.accessToken should] equal:@"6c470ffa-abf1-41aa-b866-cd3be0ee84f4"];
+        });
+        
+        it(@"should set the proper HTTP headers", ^{
+            NSError* error = [[NSError alloc] init];
+            [urlSession setResponse:[BFTask taskWithError:error] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
+            [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
+            NSURLRequest *lastRequest = urlSession.lastRequest;
+            [[[lastRequest valueForHTTPHeaderField:@"Content-Type"] should] equal:@"application/x-www-form-urlencoded"];
+        });
+        
+        it(@"should fail with a GINIError if the user credentials are incorrect", ^{
+            NSDictionary *responseData = @{
+                                           @"error": @"invalid_grant",
+                                           @"user_info": @""
+                                           };
+            [urlSession createAndSetResponse:responseData httpStatus:400 forURL:@"https://user.gini.net/oauth/token?grant_type=password" error:YES];
+            
+            BFTask *loginTask = [userCenterManager loginUser:@"foo@example.com" password:@"1234"];
+            
+            [[loginTask.error should] beKindOfClass:[GINIError class]];
+            [[theValue(loginTask.error.code) should] equal:theValue(GINIErrorInvalidCredentials)];
+        });
+        
+        it(@"should post a notification when the login was successful", ^{
+            NSDictionary *responseData = @{
+                                           @"access_token": @"6c470ffa-abf1-41aa-b866-cd3be0ee84f4",
+                                           @"token_type":   @"bearer",
+                                           @"expires_in":   @3599
+                                           };
+            [urlSession createAndSetResponse:responseData httpStatus:201 forURL:@"https://user.gini.net/oauth/token?grant_type=password" error:NO];
+            
+            [userCenterManager loginUser:@"foo@example.com" password:@"1234"];
+            
+            [[notificationCenter.lastNotification shouldNot] beNil];
+            [[notificationCenter.lastNotification.name should] equal:GINILoginNotification];
+        });
+        
+        it(@"should post a notification when there was a login error", ^{
+            NSDictionary *responseData = @{
+                                           @"error": @"invalid_grant",
+                                           @"user_info": @""
+                                           };
+            [urlSession createAndSetResponse:responseData httpStatus:400 forURL:@"https://user.gini.net/oauth/token?grant_type=password" error:YES];
+            
+            [userCenterManager loginUser:@"foo@example.com" password:@"1234"];
+            
+            [[notificationCenter.lastNotification shouldNot] beNil];
+            [[notificationCenter.lastNotification.name should] equal:GINILoginErrorNotification];
+        });
+    });
+    
+    context(@"the getAccessTokenInfoForGiniApiSession: method", ^{
+        it(@"should throw an error if getting the wrong arguments", ^{
+            [[theBlock(^{
+                [userCenterManager getUserInfo:nil];
+            }) should] raise];
+        });
+        
+        it(@"should do the HTTP request to the correct URL", ^{
+            NSString *accessToken = @"exampleToken";
+            GINISession *session = [[GINISession alloc] initWithAccessToken:accessToken refreshToken:@"" expirationDate:[NSDate date]];
+            NSString *url = [NSString stringWithFormat:@"https://user.gini.net/oauth/check_token?token=%@", accessToken];
+            [urlSession setResponse:[BFTask taskWithError:nil] forURL:url];
+            [userCenterManager getAccessTokenInfoForGiniApiSession:session];
+            checkRequest(url, @"GET");
+        });
+        
+        it(@"should return a BFTask instance", ^{
+            NSString *accessToken = @"exampleToken";
+            GINISession *session = [[GINISession alloc] initWithAccessToken:accessToken refreshToken:@"" expirationDate:[NSDate date]];
+            BFTask *task = [userCenterManager getAccessTokenInfoForGiniApiSession:session];
+            [[task should] beKindOfClass:[BFTask class]];
+        });
+    });
+    
+    context(@"the getUserIdForGiniApiSession: method", ^{
+        it(@"should throw an error if getting the wrong arguments", ^{
+            [[theBlock(^{
+                [userCenterManager getUserIdForGiniApiSession:nil];
+            }) should] raise];
+        });
+        
+        it(@"should extract the user id from the response", ^{
+            NSString *accessToken = @"exampleToken";
+            GINISession *session = [[GINISession alloc] initWithAccessToken:accessToken refreshToken:@"" expirationDate:[NSDate date]];
+            NSString *url = [NSString stringWithFormat:@"https://user.gini.net/oauth/check_token?token=%@", accessToken];
+            
+            NSURL *responseURL = [NSURL URLWithString:url];
+            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
                                                                       statusCode:201
                                                                      HTTPVersion:@"1.1"
                                                                     headerFields:nil];
             
             NSString *userId = @"JohnDoe";
-            GINIURLResponse *tokenInfoResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
-                                                                                                          @"user_name": userId
-                                                                                                          }];
-            [urlSession setResponse:[BFTask taskWithResult:tokenInfoResponse] forURL:tokenInfoUrl];
+            GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
+                                                                                                     @"user_name": userId
+                                                                                                     }];
+            [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:url];
             
-            NSString *url = [NSString stringWithFormat:@"https://user.gini.net/api/users/%@", userId];
-            [urlSession setResponse:[BFTask taskWithError:nil] forURL:url];
-            return url;
-
-        };
-
-        beforeEach(^{
-            urlSession = [GINIURLSessionMock new];
-            notificationCenter = [GININSNotificationCenterMock defaultCenter];
-            userCenterManager = [GINIUserCenterManager userCenterManagerWithURLSession:urlSession
-                                                                              clientID:@"foo"
-                                                                          clientSecret:@"bar"
-                                                                               baseURL:[NSURL URLWithString:@"https://user.gini.net/"]
-                                                                    notificationCenter:notificationCenter];
-
-            // Set the response for an authorization request, so the tests can receive an access token and can create
-            // a `GINISession` instance.
-            NSDictionary *sessionResponse = @{
-                @"access_token": @"1234-5678",
-                @"expires_in": @5000,
-                @"token_type": @"bearer"
-            };
-            [urlSession createAndSetResponse:sessionResponse httpStatus:0 forURL:@"https://user.gini.net/oauth/token?grant_type=client_credentials" error:NO];
+            BFTask *userIdTask = [userCenterManager getUserIdForGiniApiSession:session];
+            [[userIdTask.result should] beKindOfClass:[NSString class]];
+            [[userIdTask.result should] equal:userId];
         });
-
-        it(@"should raise an error if instantiated with the wrong dependencies", ^{
-            [[theBlock(^{
-                [GINIUserCenterManager userCenterManagerWithURLSession:nil clientID:nil clientSecret:nil baseURL:nil notificationCenter:nil];
-            }) should] raise];
-
-            [[theBlock(^{
-                [GINIUserCenterManager userCenterManagerWithURLSession:nil clientID:nil clientSecret:@"foo" baseURL:nil notificationCenter:nil];
-            }) should] raise];
-
-            [[theBlock(^{
-                [GINIUserCenterManager userCenterManagerWithURLSession:nil clientID:@"foo" clientSecret:@"bar" baseURL:nil notificationCenter:nil];
-            }) should] raise];
-        });
-
-        it(@"should build the correct login header", ^{
-            // Base64 of "foo:bar" (client ID : client secret)
-            [[[userCenterManager createLoginHeader] should] equal:@"Basic Zm9vOmJhcg=="];
-        });
-
-        context(@"the getUserInfo: method", ^{
-            it(@"should throw an error if getting the wrong arguments", ^{
-                [[theBlock(^{
-                    [userCenterManager getUserInfo:nil];
-                }) should] raise];
-            });
-
-            it(@"should do the HTTP request to the correct URL", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
-                [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
-                checkRequest(@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406", @"GET");
-            });
-
-            it(@"should set the correct access token", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
-                [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
-                checkAccessToken();
-            });
-
-            it(@"should return a BFTask instance", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
-                BFTask *infoTask = [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
-                [[infoTask should] beKindOfClass:[BFTask class]];
-            });
-
-            it(@"should return a task that resolves to a GINIUser instance", ^{
-                NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
-                NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
-                                                                          statusCode:201
-                                                                         HTTPVersion:@"1.1"
-                                                                        headerFields:nil];
-                GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
-                    @"id":    @"88a28076-18e8-4275-b39c-eaacc240d406",
-                    @"email": @"foobar@example.com"
-                }];
-                [urlSession setResponse:[BFTask taskWithResult:giniResponse]
-                                 forURL:@"https://user.gini.net/api/users/88a28076-18e8-4275-b39c-eaacc240d406"];
-
-                BFTask *userTask = [userCenterManager getUserInfo:@"88a28076-18e8-4275-b39c-eaacc240d406"];
-                [[userTask.result should] beKindOfClass:[GINIUser class]];
-                GINIUser *user = userTask.result;
-                [[user.userId should] equal:@"88a28076-18e8-4275-b39c-eaacc240d406"];
-                [[user.userEmail should] equal:@"foobar@example.com"];
-            });
-        });
-
-        context(@"the createUserWithEmail:password: method", ^{
-            it(@"should throw an error if getting the wrong arguments", ^{
-                [[theBlock(^{
-                    [userCenterManager createUserWithEmail:nil password:nil];
-                }) should] raise];
-
-                [[theBlock(^{
-                    [userCenterManager createUserWithEmail:@"foobar" password:nil];
-                }) should] raise];
-
-            });
-
-            it(@"should do the HTTP request to the correct URL", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users"];
-                [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-                checkRequest(@"https://user.gini.net/api/users", @"POST");
-            });
-
-            it(@"should set the correct access token", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users"];
-                [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-                checkAccessToken();
-            });
-
-            it(@"should submit the correct data", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users"];
-                [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-                NSURLRequest *lastRequest = urlSession.lastRequest;
-                NSString *expectedData = @"{\"email\":\"foobar@example.com\",\"password\":\"1234\"}";
-                NSDictionary *expectedJSON = [NSJSONSerialization JSONObjectWithData:[expectedData dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil];
-                NSString *actualData = [[NSString alloc] initWithData:lastRequest.HTTPBody encoding:NSUTF8StringEncoding];
-                NSDictionary *actualJSON = [NSJSONSerialization JSONObjectWithData:[actualData dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingAllowFragments error:nil];
-                [[expectedJSON should] equal:actualJSON];
-            });
-
-            it(@"should return a BFTask instance", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users"];
-                BFTask *createTask = [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-                [[createTask should] beKindOfClass:[BFTask class]];
-            });
-
-            it(@"should return a task that resolves to a GINIUser instance", ^{
-                NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/api/users"];
-                NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
-                                                                          statusCode:201
-                                                                         HTTPVersion:@"1.1"
-                                                                        headerFields:@{
-                                                                            @"Location": @"https://user.gini.net/api/users/c1e60c6b-a0a4-4d80-81eb-c1c6de729a0e"
-                                                                        }];
-                GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response];
-                [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:@"https://user.gini.net/api/users"];
-
-                BFTask *createTask = [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-                [[createTask.result should] beKindOfClass:[GINIUser class]];
-                GINIUser *user = createTask.result;
-                [[user.userId should] equal:@"c1e60c6b-a0a4-4d80-81eb-c1c6de729a0e"];
-                [[user.userEmail should] equal:@"foobar@example.com"];
-            });
-
-            it(@"should trigger a notification when the user was created", ^{
-                NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/api/users"];
-                NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
-                                                                          statusCode:201
-                                                                         HTTPVersion:@"1.1"
-                                                                        headerFields:@{
-                                                                                @"Location": @"https://user.gini.net/api/users/c1e60c6b-a0a4-4d80-81eb-c1c6de729a0e"
-                                                                        }];
-                GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response];
-                [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:@"https://user.gini.net/api/users"];
-
-                [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-
-                [[notificationCenter.lastNotification shouldNot] beNil];
-                [[notificationCenter.lastNotification.name should] equal:GINIUserCreationNotification];
-                [[notificationCenter.lastNotification.object should] beKindOfClass:[GINIUser class]];
-                GINIUser *user = notificationCenter.lastNotification.object;
-                [[user.userEmail should] equal:@"foobar@example.com"];
-            });
-
-            it(@"should post a notification when there was an error", ^{
-                [urlSession createAndSetResponse:nil httpStatus:500 forURL:@"https://user.gini.net/api/users" error:YES];
-
-                [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-
-                [[notificationCenter.lastNotification shouldNot] beNil];
-                [[notificationCenter.lastNotification.name should] equal:GINIUserCreationErrorNotification];
-            });
-
-            it(@"should set the proper HTTP headers", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users"];
-                [userCenterManager createUserWithEmail:@"foobar@example.com" password:@"1234"];
-                NSURLRequest *lastRequest = urlSession.lastRequest;
-                [[[lastRequest valueForHTTPHeaderField:@"Content-Type"] should] equal:@"application/json"];
-                [[[lastRequest valueForHTTPHeaderField:@"Accept"] should] equal:@"application/json"];
-            });
-        });
-
-        context(@"the loginUser:password: method", ^{
-            it(@"should throw an error if getting the wrong arguments", ^{
-                [[theBlock(^{
-                    [userCenterManager createUserWithEmail:nil password:nil];
-                }) should] raise];
-
-                [[theBlock(^{
-                    [userCenterManager createUserWithEmail:@"foobar" password:nil];
-                }) should] raise];
-
-            });
-
-            it(@"should do the HTTP request to the correct URL", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
-                [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
-                checkRequest(@"https://user.gini.net/oauth/token?grant_type=password", @"POST");
-            });
-
-            it(@"should set the correct authentication headers", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
-                [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
-                checkBasicAuthentication();
-            });
-
-            it(@"should submit the correct data", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/api/users"];
-                [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
-                NSURLRequest *lastRequest = urlSession.lastRequest;
-                NSString *expectedData = @"username=foobar%40example.com&password=1234";
-                NSString *actualData = [[NSString alloc] initWithData:lastRequest.HTTPBody encoding:NSUTF8StringEncoding];
-                [[expectedData should] equal:actualData];
-            });
-
-            it(@"should return a BFTask instance", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
-                BFTask *loginTask = [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
-                [[loginTask should] beKindOfClass:[BFTask class]];
-            });
-
-            it(@"should return a BFTask instance that resolves to a GINISession instance", ^{
-                NSURL *responseURL = [NSURL URLWithString:@"https://user.gini.net/oauth/token?grant_type=password"];
-                NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
-                                                                          statusCode:201
-                                                                         HTTPVersion:@"1.1"
-                                                                        headerFields:nil];
-                GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
-                    @"access_token": @"6c470ffa-abf1-41aa-b866-cd3be0ee84f4",
-                    @"token_type":   @"bearer",
-                    @"expires_in":   @3599
-                }];
-                [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
-
-                BFTask *loginTask = [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
-                [[loginTask.result should] beKindOfClass:[GINISession class]];
-                GINISession *session = loginTask.result;
-                [[session.accessToken should] equal:@"6c470ffa-abf1-41aa-b866-cd3be0ee84f4"];
-            });
-
-            it(@"should set the proper HTTP headers", ^{
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:@"https://user.gini.net/oauth/token?grant_type=password"];
-                [userCenterManager loginUser:@"foobar@example.com" password:@"1234"];
-                NSURLRequest *lastRequest = urlSession.lastRequest;
-                [[[lastRequest valueForHTTPHeaderField:@"Content-Type"] should] equal:@"application/x-www-form-urlencoded"];
-            });
-
-            it(@"should fail with a GINIError if the user credentials are incorrect", ^{
-                NSDictionary *responseData = @{
-                    @"error": @"invalid_grant",
-                    @"user_info": @""
-                };
-                [urlSession createAndSetResponse:responseData httpStatus:400 forURL:@"https://user.gini.net/oauth/token?grant_type=password" error:YES];
-
-                BFTask *loginTask = [userCenterManager loginUser:@"foo@example.com" password:@"1234"];
-
-                [[loginTask.error should] beKindOfClass:[GINIError class]];
-                [[theValue(loginTask.error.code) should] equal:theValue(GINIErrorInvalidCredentials)];
-            });
-
-            it(@"should post a notification when the login was successful", ^{
-                NSDictionary *responseData = @{
-                        @"access_token": @"6c470ffa-abf1-41aa-b866-cd3be0ee84f4",
-                        @"token_type":   @"bearer",
-                        @"expires_in":   @3599
-                };
-                [urlSession createAndSetResponse:responseData httpStatus:201 forURL:@"https://user.gini.net/oauth/token?grant_type=password" error:NO];
-
-                [userCenterManager loginUser:@"foo@example.com" password:@"1234"];
-
-                [[notificationCenter.lastNotification shouldNot] beNil];
-                [[notificationCenter.lastNotification.name should] equal:GINILoginNotification];
-            });
-
-            it(@"should post a notification when there was a login error", ^{
-                NSDictionary *responseData = @{
-                        @"error": @"invalid_grant",
-                        @"user_info": @""
-                };
-                [urlSession createAndSetResponse:responseData httpStatus:400 forURL:@"https://user.gini.net/oauth/token?grant_type=password" error:YES];
-
-                [userCenterManager loginUser:@"foo@example.com" password:@"1234"];
-
-                [[notificationCenter.lastNotification shouldNot] beNil];
-                [[notificationCenter.lastNotification.name should] equal:GINILoginErrorNotification];
-            });
-        });
-        
-        context(@"the getAccessTokenInfoForGiniApiSession: method", ^{
-            it(@"should throw an error if getting the wrong arguments", ^{
-                [[theBlock(^{
-                    [userCenterManager getUserInfo:nil];
-                }) should] raise];
-            });
-            
-            it(@"should do the HTTP request to the correct URL", ^{
-                NSString *accessToken = @"exampleToken";
-                GINISession *session = [[GINISession alloc] initWithAccessToken:accessToken refreshToken:@"" expirationDate:[NSDate date]];
-                NSString *url = [NSString stringWithFormat:@"https://user.gini.net/oauth/check_token?token=%@", accessToken];
-                [urlSession setResponse:[BFTask taskWithError:nil] forURL:url];
-                [userCenterManager getAccessTokenInfoForGiniApiSession:session];
-                checkRequest(url, @"GET");
-            });
-            
-            it(@"should return a BFTask instance", ^{
-                NSString *accessToken = @"exampleToken";
-                GINISession *session = [[GINISession alloc] initWithAccessToken:accessToken refreshToken:@"" expirationDate:[NSDate date]];
-                BFTask *task = [userCenterManager getAccessTokenInfoForGiniApiSession:session];
-                [[task should] beKindOfClass:[BFTask class]];
-            });
-        });
-        
-        context(@"the getUserIdForGiniApiSession: method", ^{
-            it(@"should throw an error if getting the wrong arguments", ^{
-                [[theBlock(^{
-                    [userCenterManager getUserIdForGiniApiSession:nil];
-                }) should] raise];
-            });
-            
-            it(@"should extract the user id from the response", ^{
-                NSString *accessToken = @"exampleToken";
-                GINISession *session = [[GINISession alloc] initWithAccessToken:accessToken refreshToken:@"" expirationDate:[NSDate date]];
-                NSString *url = [NSString stringWithFormat:@"https://user.gini.net/oauth/check_token?token=%@", accessToken];
-
-                NSURL *responseURL = [NSURL URLWithString:url];
-                NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:responseURL
-                                                                          statusCode:201
-                                                                         HTTPVersion:@"1.1"
-                                                                        headerFields:nil];
-                
-                NSString *userId = @"JohnDoe";
-                GINIURLResponse *giniResponse = [GINIURLResponse urlResponseWithResponse:response data:@{
-                                                                                                         @"user_name": userId
-                                                                                                         }];
-                [urlSession setResponse:[BFTask taskWithResult:giniResponse] forURL:url];
-                
-                BFTask *userIdTask = [userCenterManager getUserIdForGiniApiSession:session];
-                [[userIdTask.result should] beKindOfClass:[NSString class]];
-                [[userIdTask.result should] equal:userId];
-            });
-        });
-        
-        context(@"the updateEmail:oldEmail:giniApiSession: method", ^{
-            it(@"should throw an error if getting the wrong arguments", ^{
-                [[theBlock(^{
-                    [userCenterManager updateEmail:nil oldEmail:nil giniApiSession:nil];
-                }) should] raise];
-                
-                [[theBlock(^{
-                    [userCenterManager updateEmail:@"" oldEmail:nil giniApiSession:nil];
-                }) should] raise];
-                
-                [[theBlock(^{
-                    [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:nil];
-                }) should] raise];
-            });
-            
-            it(@"should do the HTTP request to the correct URL", ^{
-                GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
-                NSString *url = setResponsesForUpdateEmail(session);
-                
-                [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:session];
-                checkRequest(url, @"PUT");
-            });
-            
-            it(@"should set the correct authentication headers", ^{
-                GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
-                setResponsesForUpdateEmail(session);
-                
-                [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:session];
-                checkAccessToken();
-            });
-            
-            it(@"should submit the correct data", ^{
-                GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
-                setResponsesForUpdateEmail(session);
-                
-                NSString *oldEmail = @"oldEmail@example.com";
-                NSString *newEmail = @"newEmail@beispiel.com";
-                
-                [userCenterManager updateEmail:newEmail oldEmail:oldEmail giniApiSession:session];
-                NSURLRequest *lastRequest = urlSession.lastRequest;
-                NSDictionary *dataDict = [NSJSONSerialization JSONObjectWithData:lastRequest.HTTPBody options:NSJSONReadingAllowFragments error:nil];
-                
-                NSString *sentOldEmail = dataDict[@"oldEmail"];
-                NSString *sentNewEmail = dataDict[@"email"];
-                [[sentOldEmail should] equal:oldEmail];
-                [[sentNewEmail should] equal:newEmail];
-            });
-            
-            it(@"should return a BFTask instance", ^{
-                GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
-                setResponsesForUpdateEmail(session);
-                
-                BFTask *updateEmailTask = [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:session];
-                [[updateEmailTask should] beKindOfClass:[BFTask class]];
-            });
-            
-        });
-
-
     });
+    
+    context(@"the updateEmail:oldEmail:giniApiSession: method", ^{
+        it(@"should throw an error if getting the wrong arguments", ^{
+            [[theBlock(^{
+                [userCenterManager updateEmail:nil oldEmail:nil giniApiSession:nil];
+            }) should] raise];
+            
+            [[theBlock(^{
+                [userCenterManager updateEmail:@"" oldEmail:nil giniApiSession:nil];
+            }) should] raise];
+            
+            [[theBlock(^{
+                [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:nil];
+            }) should] raise];
+        });
+        
+        it(@"should do the HTTP request to the correct URL", ^{
+            GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
+            NSString *url = setResponsesForUpdateEmail(session);
+            
+            [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:session];
+            checkRequest(url, @"PUT");
+        });
+        
+        it(@"should set the correct authentication headers", ^{
+            GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
+            setResponsesForUpdateEmail(session);
+            
+            [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:session];
+            checkAccessToken();
+        });
+        
+        it(@"should submit the correct data", ^{
+            GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
+            setResponsesForUpdateEmail(session);
+            
+            NSString *oldEmail = @"oldEmail@example.com";
+            NSString *newEmail = @"newEmail@beispiel.com";
+            
+            [userCenterManager updateEmail:newEmail oldEmail:oldEmail giniApiSession:session];
+            NSURLRequest *lastRequest = urlSession.lastRequest;
+            NSDictionary *dataDict = [NSJSONSerialization JSONObjectWithData:lastRequest.HTTPBody options:NSJSONReadingAllowFragments error:nil];
+            
+            NSString *sentOldEmail = dataDict[@"oldEmail"];
+            NSString *sentNewEmail = dataDict[@"email"];
+            [[sentOldEmail should] equal:oldEmail];
+            [[sentNewEmail should] equal:newEmail];
+        });
+        
+        it(@"should return a BFTask instance", ^{
+            GINISession *session = [[GINISession alloc] initWithAccessToken:@"exampleToken" refreshToken:@"" expirationDate:[NSDate date]];
+            setResponsesForUpdateEmail(session);
+            
+            BFTask *updateEmailTask = [userCenterManager updateEmail:@"" oldEmail:@"" giniApiSession:session];
+            [[updateEmailTask should] beKindOfClass:[BFTask class]];
+        });
+        
+    });
+    
+    
+});
 
 
 

--- a/Gini-iOS-SDKTests/HelperClasses/GINIAPIManagerMock.m
+++ b/Gini-iOS-SDKTests/HelperClasses/GINIAPIManagerMock.m
@@ -30,15 +30,23 @@
 }
 
 - (BFTask *)getDocument:(NSString *)documentId{
-    _getDocumentCalled += 1;
-    return [BFTask taskWithResult:@{
-            @"id": @"1234",
-            @"progress": @"COMPLETED",
-            @"sourceClassification": @"SCANNED"
-    }];
+    return [self getDocument:documentId cancellationToken:nil];
 }
 
-- (BFTask *)uploadDocumentWithData:(NSData *)documentData contentType:(NSString *)contentType fileName:(NSString *)fileName docType:(NSString *)docType {
+- (BFTask *)getDocument:(NSString *)documentId cancellationToken:(BFCancellationToken *)cancellationToken {
+    _getDocumentCalled += 1;
+    return [BFTask taskWithResult:@{
+                                    @"id": @"1234",
+                                    @"progress": @"COMPLETED",
+                                    @"sourceClassification": @"SCANNED"
+                                    }];
+}
+
+- (BFTask *)uploadDocumentWithData:(NSData *)documentData
+                       contentType:(NSString *)contentType
+                          fileName:(NSString *)fileName
+                           docType:(NSString *)docType
+                 cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([documentData isKindOfClass:[NSData class]]);
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([contentType isKindOfClass:[NSString class]]);

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - Bolts (1.1.5):
-    - Bolts/AppLinks (= 1.1.5)
-    - Bolts/Tasks (= 1.1.5)
-  - Bolts/AppLinks (1.1.5):
+  - Bolts (1.9.0):
+    - Bolts/AppLinks (= 1.9.0)
+    - Bolts/Tasks (= 1.9.0)
+  - Bolts/AppLinks (1.9.0):
     - Bolts/Tasks
-  - Bolts/Tasks (1.1.5)
+  - Bolts/Tasks (1.9.0)
   - Gini-iOS-SDK (0.6.0):
     - Gini-iOS-SDK/Core (= 0.6.0)
   - Gini-iOS-SDK/Core (0.6.0):
-    - Bolts (~> 1.1.5)
+    - Bolts (~> 1.9)
   - Gini-iOS-SDK/Pinning (0.6.0):
-    - Bolts (~> 1.1.5)
-    - TrustKit (~> 1.5.2)
+    - Bolts (~> 1.9)
+    - TrustKit (~> 1.5)
   - Kiwi (2.4.0)
-  - TrustKit (1.5.2)
+  - TrustKit (1.5.3)
 
 DEPENDENCIES:
   - Gini-iOS-SDK (from `./`)
@@ -25,10 +25,10 @@ EXTERNAL SOURCES:
     :path: ./
 
 SPEC CHECKSUMS:
-  Bolts: aac24961496d504aa56fc267cde95162a71bac39
-  Gini-iOS-SDK: 75c35076dbbdeff5b7ac8c90b8cbd63274dbc209
+  Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
+  Gini-iOS-SDK: 9bd979ca07dbd420ec4bf63c96e1dacd0e32af9c
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
-  TrustKit: fd852155aa95a02da40e2c2e0aa9060937a88abe
+  TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 0dbabbd31fc2a03f4c7c928185f82a5ee842dc13
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - Bolts/AppLinks (1.9.0):
     - Bolts/Tasks
   - Bolts/Tasks (1.9.0)
-  - Gini-iOS-SDK (0.6.0):
-    - Gini-iOS-SDK/Core (= 0.6.0)
-  - Gini-iOS-SDK/Core (0.6.0):
+  - Gini-iOS-SDK (1.0.0-alpha.1):
+    - Gini-iOS-SDK/Core (= 1.0.0-alpha.1)
+  - Gini-iOS-SDK/Core (1.0.0-alpha.1):
     - Bolts (~> 1.9)
-  - Gini-iOS-SDK/Pinning (0.6.0):
+  - Gini-iOS-SDK/Pinning (1.0.0-alpha.1):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
   - Kiwi (2.4.0)
@@ -26,7 +26,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
-  Gini-iOS-SDK: 9bd979ca07dbd420ec4bf63c96e1dacd0e32af9c
+  Gini-iOS-SDK: 5b1de7265013626e418df9781a9f5f0cbd2b9b2a
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 


### PR DESCRIPTION
Since Bolts 1.2.0 there is the option to add a cancellation token for the tasks. It was added the possibility to add a cancellation token for each request that could need it. So now there is no need to handle the cancellation outside of the library.
Also every place where BFTask exception where used, has been removed since it caused big leaks.

### How to test
Initialize a `BFCancellationTokenSource` and pass its token when creating a document or asking for documents. Cancel the token before it ends.

### Merging
Automatic.

Issues #63 and #64   