### PR TITLE
Multipage document creation

### DIFF
--- a/Gini-iOS-SDK.xcodeproj/project.pbxproj
+++ b/Gini-iOS-SDK.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0A845B941DAE9AC300AD2D64 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A845B931DAE9AC300AD2D64 /* Assets.xcassets */; };
 		0A845B971DAE9AC300AD2D64 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A845B951DAE9AC300AD2D64 /* LaunchScreen.storyboard */; };
 		0ADEEE6D1BEA0549002BB08E /* GINIHTTPErrorSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ADEEE6C1BEA0549002BB08E /* GINIHTTPErrorSpec.m */; };
+		1F384558207B4D4A0022B643 /* compositedocument.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F384557207B4D4A0022B643 /* compositedocument.json */; };
 		1F3C8C74202DB5FB0023E55F /* GININSNotificationCenterMock.m in Sources */ = {isa = PBXBuildFile; fileRef = C753E51E0C870474ADACAC6A /* GININSNotificationCenterMock.m */; };
 		23D53C061934BC85001A957E /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23D53C051934BC85001A957E /* XCTest.framework */; };
 		23D53C071934BC85001A957E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23D53BF71934BC85001A957E /* Foundation.framework */; };
@@ -90,6 +91,7 @@
 		0A845B9C1DAE9B3500AD2D64 /* GiniSDK Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "GiniSDK Example.entitlements"; sourceTree = "<group>"; };
 		0ADEEE6C1BEA0549002BB08E /* GINIHTTPErrorSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GINIHTTPErrorSpec.m; sourceTree = "<group>"; };
 		101F203A8C65DF93F5B03B04 /* libPods-Gini-iOS-SDKTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Gini-iOS-SDKTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F384557207B4D4A0022B643 /* compositedocument.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = compositedocument.json; sourceTree = "<group>"; };
 		23D53BF71934BC85001A957E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		23D53C041934BC85001A957E /* Gini-iOS-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Gini-iOS-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		23D53C051934BC85001A957E /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -303,6 +305,7 @@
 				81EE468AFDEFC8942E20F31F /* yoda.jpg */,
 				81EE4FC272A3BC02720C26F5 /* document.json */,
 				81EE409560F238177896AAE6 /* session.json */,
+				1F384557207B4D4A0022B643 /* compositedocument.json */,
 				04A595B1195869DD00CB8E1B /* documents.json */,
 				04B75484195AAC5000CF6072 /* extractions.json */,
 				04A595C119598DD300CB8E1B /* pages.json */,
@@ -437,6 +440,7 @@
 				81EE4EA88FD761DB89CC3337 /* session.json in Resources */,
 				04A595B2195869DD00CB8E1B /* documents.json in Resources */,
 				59A96DC1EF05B7643FBD6471 /* errorreport.json in Resources */,
+				1F384558207B4D4A0022B643 /* compositedocument.json in Resources */,
 				59A9690C3E4F8E47848268A1 /* feedback.json in Resources */,
 				59A96D965DF351F797FD85E0 /* layout.xml in Resources */,
 			);

--- a/Gini-iOS-SDK.xcodeproj/project.pbxproj
+++ b/Gini-iOS-SDK.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		0A845B941DAE9AC300AD2D64 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0A845B931DAE9AC300AD2D64 /* Assets.xcassets */; };
 		0A845B971DAE9AC300AD2D64 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A845B951DAE9AC300AD2D64 /* LaunchScreen.storyboard */; };
 		0ADEEE6D1BEA0549002BB08E /* GINIHTTPErrorSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ADEEE6C1BEA0549002BB08E /* GINIHTTPErrorSpec.m */; };
+		1F12130720909F0D00945582 /* GINIPartialDocumentInfoSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F12130620909F0D00945582 /* GINIPartialDocumentInfoSpec.m */; };
 		1F384558207B4D4A0022B643 /* compositedocument.json in Resources */ = {isa = PBXBuildFile; fileRef = 1F384557207B4D4A0022B643 /* compositedocument.json */; };
 		1F3C8C74202DB5FB0023E55F /* GININSNotificationCenterMock.m in Sources */ = {isa = PBXBuildFile; fileRef = C753E51E0C870474ADACAC6A /* GININSNotificationCenterMock.m */; };
 		23D53C061934BC85001A957E /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23D53C051934BC85001A957E /* XCTest.framework */; };
@@ -91,6 +92,7 @@
 		0A845B9C1DAE9B3500AD2D64 /* GiniSDK Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "GiniSDK Example.entitlements"; sourceTree = "<group>"; };
 		0ADEEE6C1BEA0549002BB08E /* GINIHTTPErrorSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GINIHTTPErrorSpec.m; sourceTree = "<group>"; };
 		101F203A8C65DF93F5B03B04 /* libPods-Gini-iOS-SDKTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Gini-iOS-SDKTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F12130620909F0D00945582 /* GINIPartialDocumentInfoSpec.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GINIPartialDocumentInfoSpec.m; sourceTree = "<group>"; };
 		1F384557207B4D4A0022B643 /* compositedocument.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = compositedocument.json; sourceTree = "<group>"; };
 		23D53BF71934BC85001A957E /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		23D53C041934BC85001A957E /* Gini-iOS-SDKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Gini-iOS-SDKTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -248,6 +250,7 @@
 				C753E14CEE34C4191333A19E /* GINIKeychainManagerSpec.m */,
 				C753ECA47058756178576D14 /* GINIKeychainCredentialsStoreSpec.m */,
 				59A9614FFB0DC06682809850 /* GINIUserSpec.m */,
+				1F12130620909F0D00945582 /* GINIPartialDocumentInfoSpec.m */,
 				C753E988D87DD1037B2E1418 /* GINIUserCenterManagerSpec.m */,
 				C753E1D596C35E25BD8B3CC4 /* GiniSessionManagerAnonymousSpec.m */,
 				C753EA522A6C49C6975D8067 /* GINISDKBuilderSpec.m */,
@@ -578,6 +581,7 @@
 			files = (
 				E2529A471947599A00FE8527 /* GINISessionManagerSpecs.m in Sources */,
 				81EE44133FBD4D2243E5D77D /* GINIURLSessionMock.m in Sources */,
+				1F12130720909F0D00945582 /* GINIPartialDocumentInfoSpec.m in Sources */,
 				81EE4016DD5977EA419AAB82 /* GINISessionManagerMock.m in Sources */,
 				E2529A451947599500FE8527 /* GINIURLResponseSpec.m in Sources */,
 				E2529A431947598E00FE8527 /* GINIAPIManagerSpec.m in Sources */,

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -212,6 +212,8 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 /**
  * Creates a new composite document
  *
+ * See the [Gini API Documentation](Add documentation link).
+ *
  * @param partialDocumentsInfo  Array containing the partial documents info. More info can be found [here](Add here documentation link)
  * @param fileName              The filename of the document.
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -210,22 +210,22 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 
 
 /**
- * Creates a new multi whatever document
+ * Creates a new composite document
  *
- * @param subDocumentsURLs  Array containing the URL for each sub document.
- * @param fileName          The filename of the document.
- * @param docType           (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
- *                          [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
- *                          for a list of possibles doctypes.
- * @param cancellationToken Cancellation token used to cancel the current task.
+ * @param partialDocumentsURLs  Array containing the URL path for each partial document.
+ * @param fileName              The filename of the document.
+ * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
+ *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
+ *                              for a list of possibles doctypes.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
  *
- * @returns                 A`BFTask*` that will resolve to a NSString containing the created document's ID.
+ * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
  */
 
-- (BFTask *)uploadMultipageDocumentWithSubDocumentsURLs:(NSArray<NSURL*>*)subDocumentsURLs
-                                               fileName:(NSString *)fileName
-                                                docType:(NSString *)docType
-                                      cancellationToken:(BFCancellationToken *) cancellationToken;
+- (BFTask *)createCompositeDocumentWithPartialDocumentsURLs:(NSArray<NSString*>*)partialDocumentsURLs
+                                                   fileName:(NSString *)fileName
+                                                    docType:(NSString *)docType
+                                          cancellationToken:(BFCancellationToken *) cancellationToken;
 
 
 /**

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -212,7 +212,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 /**
  * Creates a new composite document
  *
- * @param partialDocumentsURLs  Array containing the URL path for each partial document.
+ * @param partialDocumentsInfo  Array containing the partial documents info (document url and additional parameters).
  * @param fileName              The filename of the document.
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
  *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
@@ -222,7 +222,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
  */
 
-- (BFTask *)createCompositeDocumentWithPartialDocumentsURLs:(NSArray<NSString*>*)partialDocumentsURLs
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<NSDictionary<NSString*, id>*>*)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *) cancellationToken;

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -209,10 +209,23 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
                  cancellationToken:(BFCancellationToken *) cancellationToken;
 
 
-- (BFTask *)uploadMultipageDocumentWithSubDocumentURLs:(NSArray<NSURL*>*)subDocumentURLs
-                                             fileName:(NSString *)fileName
-                                              docType:(NSString *)docType
-                                    cancellationToken:(BFCancellationToken *) cancellationToken;
+/**
+ * Creates a new multi whatever document
+ *
+ * @param subDocumentsURLs  Array containing the URL for each sub document.
+ * @param fileName          The filename of the document.
+ * @param docType           (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
+ *                          [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
+ *                          for a list of possibles doctypes.
+ * @param cancellationToken Cancellation token used to cancel the current task.
+ *
+ * @returns                 A`BFTask*` that will resolve to a NSString containing the created document's ID.
+ */
+
+- (BFTask *)uploadMultipageDocumentWithSubDocumentsURLs:(NSArray<NSURL*>*)subDocumentsURLs
+                                               fileName:(NSString *)fileName
+                                                docType:(NSString *)docType
+                                      cancellationToken:(BFCancellationToken *) cancellationToken;
 
 
 /**

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -5,6 +5,7 @@
 
 @class BFTask;
 @class BFCancellationToken;
+@class GINIPartialDocumentInfo;
 @protocol GINIAPIManagerRequestFactory;
 @protocol GINIURLSession;
 
@@ -224,7 +225,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
  */
 
-- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<NSDictionary<NSString*, id>*>*)partialDocumentsInfo
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *>*)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *) cancellationToken;

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -212,7 +212,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 /**
  * Creates a new composite document
  *
- * @param partialDocumentsInfo  Array containing the partial documents info (document url and additional parameters).
+ * @param partialDocumentsInfo  Array containing the partial documents info. More info can be found [here](Add here documentation link)
  * @param fileName              The filename of the document.
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
  *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -208,6 +208,13 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
                            docType:(NSString *)docType
                  cancellationToken:(BFCancellationToken *) cancellationToken;
 
+
+- (BFTask *)uploadMultipageDocumentWithSubDocumentURLs:(NSArray<NSURL*>*)subDocumentURLs
+                                             fileName:(NSString *)fileName
+                                              docType:(NSString *)docType
+                                    cancellationToken:(BFCancellationToken *) cancellationToken;
+
+
 /**
  * Deletes the document with the given ID.
  *

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -203,11 +203,11 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     } cancellationToken:cancellationToken];
 }
 
--(BFTask *)createCompositeDocumentWithPartialDocumentsURLs:(NSArray<NSString *> *)partialDocumentsURLs
-                                                  fileName:(NSString *)fileName
-                                                   docType:(NSString *)docType
-                                         cancellationToken:(BFCancellationToken *)cancellationToken {
-    NSDictionary* dict = @{@"subdocuments": partialDocumentsURLs};
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<NSDictionary<NSString *,id> *> *)partialDocumentsInfo
+                                                   fileName:(NSString *)fileName
+                                                    docType:(NSString *)docType
+                                          cancellationToken:(BFCancellationToken *)cancellationToken {   
+    NSDictionary* dict = @{@"subdocuments": partialDocumentsInfo};
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
                                                        options:NSJSONWritingPrettyPrinted

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -87,7 +87,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             cancellationToken:(BFCancellationToken *)cancellationToken {
     return [[_requestFactory asynchronousRequestUrl:location withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *documentTask) {
             GINIURLResponse *response = documentTask.result;
             return response.data;
@@ -133,7 +133,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"documents/%@/pages", documentId] relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *pagesTask) {
             GINIURLResponse *response = pagesTask.result;
             return response.data;
@@ -155,9 +155,9 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
         if (responseType == GiniAPIResponseTypeJSON) {
-            [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Accept"];
+            [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
         } else {
-            [request setValue:@"application/vnd.gini.v1+xml" forHTTPHeaderField:@"Accept"];
+            [request setValue:@"application/vnd.gini.v2+xml" forHTTPHeaderField:@"Accept"];
         }
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *layoutTask) {
             GINIURLResponse *response = layoutTask.result;
@@ -269,7 +269,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     NSURL *url = [NSURL URLWithString:urlString relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *documentsTask) {
             GINIURLResponse *response = documentsTask.result;
             return response.data;
@@ -283,7 +283,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 
 - (BFTask *)getExtractionsForDocument:(NSString *)documentId
                     cancellationToken:(BFCancellationToken *)cancellationToken {
-    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.v1+json" cancellationToken:cancellationToken];
+    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.v2+json" cancellationToken:cancellationToken];
 }
 
 - (BFTask *)getIncubatorExtractionsForDocument:(NSString *)documentId {
@@ -325,7 +325,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"PUT"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Content-Type"];
         NSDictionary *feedbackDict = @{@"box": boundingBox, @"value": value};
         NSData *feedbackData = [NSJSONSerialization dataWithJSONObject:feedbackDict
                                                                options:NSJSONWritingPrettyPrinted
@@ -347,7 +347,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"PUT"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Content-Type"];
         NSData *feedbackData = [NSJSONSerialization dataWithJSONObject:@{@"feedback": feedback}
                                                                options:NSJSONWritingPrettyPrinted
                                                                  error:nil];
@@ -395,7 +395,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *searchTask) {
             GINIURLResponse *response = searchTask.result;
             return response.data;
@@ -416,7 +416,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"POST"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v1+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Content-Type"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *reportErrorTask) {
             GINIURLResponse *response = reportErrorTask.result;
             return response.data;

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -207,7 +207,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *)cancellationToken {   
-    NSDictionary* dict = @{@"subdocuments": partialDocumentsInfo};
+    NSDictionary* dict = @{@"partialDocuments": partialDocumentsInfo};
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
                                                        options:NSJSONWritingPrettyPrinted

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -10,6 +10,8 @@
 #import "GINIURLSession.h"
 #import "GINIURLResponse.h"
 #import "NSString+GINIAdditions.h"
+#import "GINIConstants.h"
+#import "GINIPartialDocumentInfo.h"
 
 /**
  * Returns the string that is part of the URL of an API request for the given image preview size.
@@ -87,7 +89,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             cancellationToken:(BFCancellationToken *)cancellationToken {
     return [[_requestFactory asynchronousRequestUrl:location withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *documentTask) {
             GINIURLResponse *response = documentTask.result;
             return response.data;
@@ -133,7 +135,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"documents/%@/pages", documentId] relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *pagesTask) {
             GINIURLResponse *response = pagesTask.result;
             return response.data;
@@ -155,9 +157,9 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
         if (responseType == GiniAPIResponseTypeJSON) {
-            [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
+            [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Accept"];
         } else {
-            [request setValue:@"application/vnd.gini.v2+xml" forHTTPHeaderField:@"Accept"];
+            [request setValue:GINIContentXmlV2 forHTTPHeaderField:@"Accept"];
         }
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *layoutTask) {
             GINIURLResponse *response = layoutTask.result;
@@ -203,12 +205,11 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     } cancellationToken:cancellationToken];
 }
 
-- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<NSDictionary<NSString *,id> *> *)partialDocumentsInfo
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *>*)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
-                                          cancellationToken:(BFCancellationToken *)cancellationToken {   
-    NSDictionary* dict = @{@"partialDocuments": partialDocumentsInfo};
-    NSData *jsonDataFormatted = [self jsonDataFormattedFromDictionary:dict];
+                                          cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSData *jsonDataFormatted = [self partialDocumentsJsonFormattedFromArray:partialDocumentsInfo];
     
     NSString *urlString = [NSString stringWithFormat:@"documents/?filename=%@", stringByEscapingString(fileName)];
     if (docType) {
@@ -218,7 +219,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     NSURL *url = [NSURL URLWithString:urlString relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"POST"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2.composite+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:GINICompositeJsonV2 forHTTPHeaderField:@"Content-Type"];
         
         return [[self->_urlSession BFUploadTaskWithRequest:requestTask.result fromData:jsonDataFormatted] continueWithSuccessBlock:^id(BFTask *uploadTask) {
             // The HTTP response has a Location header with the URL of the document.
@@ -263,7 +264,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     NSURL *url = [NSURL URLWithString:urlString relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *documentsTask) {
             GINIURLResponse *response = documentsTask.result;
             return response.data;
@@ -277,7 +278,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 
 - (BFTask *)getExtractionsForDocument:(NSString *)documentId
                     cancellationToken:(BFCancellationToken *)cancellationToken {
-    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.v2+json" cancellationToken:cancellationToken];
+    return [self getExtractionsForDocument:documentId withHeader:GINIContentJsonV2 cancellationToken:cancellationToken];
 }
 
 - (BFTask *)getIncubatorExtractionsForDocument:(NSString *)documentId {
@@ -286,7 +287,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 
 -(BFTask *)getIncubatorExtractionsForDocument:(NSString *)documentId
                             cancellationToken:(BFCancellationToken *)cancellationToken {
-    return [self getExtractionsForDocument:documentId withHeader:@"application/vnd.gini.incubator+json" cancellationToken:cancellationToken];
+    return [self getExtractionsForDocument:documentId withHeader:GINIIncubatorJson cancellationToken:cancellationToken];
 }
 
 - (BFTask *)getExtractionsForDocument:(NSString *)documentId
@@ -319,7 +320,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"PUT"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Content-Type"];
         NSDictionary *feedbackDict = @{@"box": boundingBox, @"value": value};
         NSData *feedbackData = [NSJSONSerialization dataWithJSONObject:feedbackDict
                                                                options:NSJSONWritingPrettyPrinted
@@ -341,7 +342,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"PUT"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Content-Type"];
         NSData *feedbackData = [NSJSONSerialization dataWithJSONObject:@{@"feedback": feedback}
                                                                options:NSJSONWritingPrettyPrinted
                                                                  error:nil];
@@ -389,7 +390,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Accept"];
+        [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *searchTask) {
             GINIURLResponse *response = searchTask.result;
             return response.data;
@@ -410,7 +411,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
 
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"POST"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:GINIContentJsonV2 forHTTPHeaderField:@"Content-Type"];
         return [[self->_urlSession BFDataTaskWithRequest:request] continueWithSuccessBlock:^id(BFTask *reportErrorTask) {
             GINIURLResponse *response = reportErrorTask.result;
             return response.data;
@@ -418,14 +419,13 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     }];
 }
 
-- (NSData *)jsonDataFormattedFromDictionary:(NSDictionary *)dictionary {
-    NSError *error;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary
-                                                       options:NSJSONWritingPrettyPrinted
-                                                         error:&error];
-    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    NSString *jsonStringFormatted = [jsonString stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
-    NSData *jsonDataFormatted = [jsonStringFormatted dataUsingEncoding:NSUTF8StringEncoding];
+- (NSData *)partialDocumentsJsonFormattedFromArray:(NSArray<GINIPartialDocumentInfo* >*)partialDocumentsInfo {
+    NSMutableArray *partialInfoFormattedJsonStrings = [NSMutableArray new];
+    for (GINIPartialDocumentInfo* partialDocumentInfo in partialDocumentsInfo) {
+        [partialInfoFormattedJsonStrings addObject:[partialDocumentInfo formattedJson]];
+    }
+    NSString* jsonDataFormattedString = [NSString stringWithFormat: @"{\"partialDocuments\": [%@]}", [partialInfoFormattedJsonStrings componentsJoinedByString:@","]];
+    NSData *jsonDataFormatted = [jsonDataFormattedString dataUsingEncoding:NSUTF8StringEncoding];
     return jsonDataFormatted;
 }
 

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -203,17 +203,11 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     } cancellationToken:cancellationToken];
 }
 
--(BFTask *)uploadMultipageDocumentWithSubDocumentsURLs:(NSArray<NSURL *> *)subDocumentsURLs
-                                              fileName:(NSString *)fileName
-                                               docType:(NSString *)docType
-                                     cancellationToken:(BFCancellationToken *)cancellationToken {
-    
-    NSMutableArray<NSString*> *subDocumentsUrlStrings = [NSMutableArray array];
-    
-    for (NSURL* currentURL in subDocumentsURLs) {
-        [subDocumentsUrlStrings addObject:currentURL.absoluteString];
-    }
-    NSDictionary* dict = @{@"subdocuments": subDocumentsUrlStrings};
+-(BFTask *)createCompositeDocumentWithPartialDocumentsURLs:(NSArray<NSString *> *)partialDocumentsURLs
+                                                  fileName:(NSString *)fileName
+                                                   docType:(NSString *)docType
+                                         cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSDictionary* dict = @{@"subdocuments": partialDocumentsURLs};
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
                                                        options:NSJSONWritingPrettyPrinted

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -224,7 +224,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     NSURL *url = [NSURL URLWithString:urlString relativeToURL:_baseURL];
     return [[_requestFactory asynchronousRequestUrl:url withMethod:@"POST"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *request = requestTask.result;
-        [request setValue:@"application/vnd.gini.v2.document+json" forHTTPHeaderField:@"Content-Type"];
+        [request setValue:@"application/vnd.gini.v2.composite+json" forHTTPHeaderField:@"Content-Type"];
         
         return [[self->_urlSession BFUploadTaskWithRequest:requestTask.result fromData:jsonDataFormatted] continueWithSuccessBlock:^id(BFTask *uploadTask) {
             // The HTTP response has a Location header with the URL of the document.

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -203,14 +203,14 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     } cancellationToken:cancellationToken];
 }
 
--(BFTask *)uploadMultipageDocumentWithSubDocumentURLs:(NSArray<NSURL *> *)subDocumentURLs
-                                            fileName:(NSString *)fileName
-                                             docType:(NSString *)docType
-                                   cancellationToken:(BFCancellationToken *)cancellationToken {
+-(BFTask *)uploadMultipageDocumentWithSubDocumentsURLs:(NSArray<NSURL *> *)subDocumentsURLs
+                                              fileName:(NSString *)fileName
+                                               docType:(NSString *)docType
+                                     cancellationToken:(BFCancellationToken *)cancellationToken {
     
     NSMutableArray<NSString*> *subDocumentsUrlStrings = [NSMutableArray array];
     
-    for (NSURL* currentURL in subDocumentURLs) {
+    for (NSURL* currentURL in subDocumentsURLs) {
         [subDocumentsUrlStrings addObject:currentURL.absoluteString];
     }
     NSDictionary* dict = @{@"subdocuments": subDocumentsUrlStrings};

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -208,13 +208,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *)cancellationToken {   
     NSDictionary* dict = @{@"partialDocuments": partialDocumentsInfo};
-    NSError *error;
-    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
-                                                       options:NSJSONWritingPrettyPrinted
-                                                         error:&error];
-    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-    NSString *jsonStringFormatted = [jsonString stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
-    NSData *jsonDataFormatted = [jsonStringFormatted dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *jsonDataFormatted = [self jsonDataFormattedFromDictionary:dict];
     
     NSString *urlString = [NSString stringWithFormat:@"documents/?filename=%@", stringByEscapingString(fileName)];
     if (docType) {
@@ -422,6 +416,17 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
             return response.data;
         }];
     }];
+}
+
+- (NSData *)jsonDataFormattedFromDictionary:(NSDictionary *)dictionary {
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary
+                                                       options:NSJSONWritingPrettyPrinted
+                                                         error:&error];
+    NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    NSString *jsonStringFormatted = [jsonString stringByReplacingOccurrencesOfString:@"\\/" withString:@"/"];
+    NSData *jsonDataFormatted = [jsonStringFormatted dataUsingEncoding:NSUTF8StringEncoding];
+    return jsonDataFormatted;
 }
 
 @end

--- a/Gini-iOS-SDK/GINIConstants.h
+++ b/Gini-iOS-SDK/GINIConstants.h
@@ -1,0 +1,24 @@
+//
+//  GINIConstants.h
+//  Gini-iOS-SDK
+//
+//  Created by Gini GmbH on 4/25/18.
+//
+
+extern NSString* const GINIContentApplicationJson;
+extern NSString* const GINIContentApplicationXml;
+extern NSString* const GINIContentJsonV1;
+extern NSString* const GINIContentXmlV1;
+extern NSString* const GINIContentJsonV2;
+extern NSString* const GINIContentXmlV2;
+extern NSString* const GINICompositeJsonV2;
+extern NSString* const GINIPartialTypeV2;
+extern NSString* const GINIIncubatorJson;
+extern NSString* const GINIIncubatorXml;
+
+extern NSString* const ExtractionAmountToPayKey;
+extern NSString* const ExtractionPaymentReferenceKey;
+extern NSString* const ExtractionPaymentRecipientKey;
+extern NSString* const ExtractionIbanKey;
+extern NSString* const ExtractionBicKey;
+extern NSString* const ExtractionPaymentPurposeKey;

--- a/Gini-iOS-SDK/GINIConstants.m
+++ b/Gini-iOS-SDK/GINIConstants.m
@@ -1,0 +1,32 @@
+//
+//  GINIConstants.m
+//  Gini-iOS-SDK
+//
+//  Created by Gini GmbH on 4/25/18.
+//
+
+#import <Foundation/Foundation.h>
+#import "GINIConstants.h"
+
+// Content Type
+
+NSString* const GINIContentApplicationJson = @"application/json";
+NSString* const GINIContentApplicationXml = @"application/xml";
+NSString* const GINIContentJsonV1 = @"application/vnd.gini.v1+json";
+NSString* const GINIContentXmlV1 = @"application/vnd.gini.v1+xml";
+NSString* const GINIContentJsonV2 = @"application/vnd.gini.v2+json";
+NSString* const GINIContentXmlV2 = @"application/vnd.gini.v2+xml";
+NSString* const GINICompositeJsonV2 = @"application/vnd.gini.v2.composite+json";
+NSString* const GINIPartialTypeV2 = @"application/vnd.gini.v2.partial+%@";
+NSString* const GINIIncubatorJson = @"application/vnd.gini.incubator+json";
+NSString* const GINIIncubatorXml = @"application/vnd.gini.incubator+xml";
+
+
+// Extraction keys
+
+NSString* const ExtractionAmountToPayKey = @"amountToPay";
+NSString* const ExtractionPaymentReferenceKey = @"paymentReference";
+NSString* const ExtractionPaymentRecipientKey = @"paymentRecepient";
+NSString* const ExtractionIbanKey = @"iban";
+NSString* const ExtractionBicKey = @"bic";
+NSString* const ExtractionPaymentPurposeKey = @"paymentPurpose";

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -5,6 +5,7 @@
 
 #import <Foundation/Foundation.h>
 #import "GINIAPIManager.h"
+#import "GINIDocumentLinks.h"
 
 @class GINIDocumentTaskManager;
 
@@ -59,6 +60,8 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 @property (readonly) BFTask *candidates;
 /// A `BFTask*` resolving to a dictionary with the layout of the document.
 @property (readonly) BFTask *layout;
+/// Links to related resources, such as extractions, document, processed or layout.
+@property (readonly) GINIDocumentLinks *links;
 
 /**
  * Factory to create a new document.
@@ -84,6 +87,24 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
                  pageCount:(NSUInteger)pageCount
       sourceClassification:(GiniDocumentSourceClassification)sourceClassification
            documentManager:(GINIDocumentTaskManager *)documentManager;
+
+/**
+ * The designated initializer.
+ *
+ * @param documentId            The document's unique identifier.
+ * @param state                 The document's state.
+ * @param pageCount             The number of pages of the document.
+ * @param sourceClassification  The document's source classification.
+ * @param documentManager       The document manager that is used to get the additional data, e.g. for the `extractions`
+ *                              and `layout` property.
+ * @param links                 The document list of related resources (extractions, document, processed or layout).
+ */
+- (instancetype)initWithId:(NSString *)documentId
+                     state:(GiniDocumentState)state
+                 pageCount:(NSUInteger)pageCount
+      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
+           documentManager:(GINIDocumentTaskManager *)documentManager
+                     links:(GINIDocumentLinks *)links;
 
 /**
  * Gets the preview image for the given page.

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -63,35 +63,21 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 /// (Optional) Array containing the path of every partial document
 @property (readonly) NSArray<NSString *> *partialDocuments;
 /// A `BFTask*` resolving to a mapping with extractions (extraction name as key).
-@property (readonly) BFTask *extractions __attribute__((unavailable("use `GINIDocumentTaskManager.getExtractionsForDocument:` method instead")));
+@property (readonly) BFTask *extractions __attribute__((deprecated("use `GINIDocumentTaskManager.getExtractionsForDocument:` method instead")));
 /// A `BFTask*` resolving to a mapping with the candidates (extraction entity as key).
-@property (readonly) BFTask *candidates __attribute__((unavailable("use `GINIDocumentTaskManager.getCandidatesForDocument:` method instead")));
+@property (readonly) BFTask *candidates __attribute__((deprecated("use `GINIDocumentTaskManager.getCandidatesForDocument:` method instead")));
 /// A `BFTask*` resolving to a dictionary with the layout of the document.
-@property (readonly) BFTask *layout __attribute__((unavailable("use `GINIDocumentTaskManager.getLayoutForDocument:` method instead")));
+@property (readonly) BFTask *layout __attribute__((deprecated("use `GINIDocumentTaskManager.getLayoutForDocument:` method instead")));
 
 
 /**
  * Factory to create a new document.
  *
- * @param apiResponse       A dictionary containing the document information. Usually the response of the Gini API.
+ * @param apiResponse           A dictionary containing the document information. Usually the response of the Gini API.
+ * @param documentManager       The document manager that is used to get the additional data, e.g. for the `extractions`
  *
  */
-+ (instancetype)documentFromAPIResponse:(NSDictionary *)apiResponse;
-
-/**
- * The designated initializer.
- *
- * @param documentId            The document's unique identifier.
- * @param state                 The document's state.
- * @param pageCount             The number of pages of the document.
- * @param sourceClassification  The document's source classification.
- * @param links                 The document list of related resources (extractions, document, processed or layout).
- */
-- (instancetype)initWithId:(NSString *)documentId
-                     state:(GiniDocumentState)state
-                 pageCount:(NSUInteger)pageCount
-      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
-                     links:(GINIDocumentLinks *)links;
++ (instancetype)documentFromAPIResponse:(NSDictionary *)apiResponse withDocumentManager:(GINIDocumentTaskManager *)documentManager;
 
 /**
  * The designated initializer.
@@ -113,6 +99,21 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
           partialDocuments:(NSArray<NSString *> *)partialDocuments;
 
 /**
+ * The designated initializer.
+ *
+ * @param documentId            The document's unique identifier.
+ * @param state                 The document's state.
+ * @param pageCount             The number of pages of the document.
+ * @param sourceClassification  The document's source classification.
+ * @param documentManager       The document manager that is used to get the additional data, e.g. for the `extractions`
+ */
+- (instancetype)initWithId:(NSString *)documentId
+                     state:(GiniDocumentState)state
+                 pageCount:(NSUInteger)pageCount
+      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
+           documentManager:(GINIDocumentTaskManager *)documentManager __attribute__((deprecated("use `initWithId:state:pageCount:sourceClassification:links:parents:partialDocuments:` initializer instead")));
+
+/**
  * Gets the preview image for the given page.
  *
  * @param size              The size of the rendered preview. Please notice that those sizes are the maximum sizes of the
@@ -122,6 +123,6 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  *                          document are processed by the Gini API.
  */
 - (BFTask *)previewWithSize:(GiniApiPreviewSize)size
-                    forPage:(NSUInteger)page __attribute__((unavailable("use `GINIDocumentTaskManager.getPreviewForPage:ofDocument:withSize:` method instead")));
+                    forPage:(NSUInteger)page __attribute__((deprecated("Use `GINIDocumentTaskManager.getPreviewForPage:ofDocument:withSize:` method instead")));
 
 @end

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -54,12 +54,6 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 @property NSDate *creationDate;
 /// The document's source classification.
 @property GiniDocumentSourceClassification sourceClassification;
-/// A `BFTask*` resolving to a mapping with extractions (extraction name as key).
-@property (readonly) BFTask *extractions;
-/// A `BFTask*` resolving to a mapping with the candidates (extraction entity as key).
-@property (readonly) BFTask *candidates;
-/// A `BFTask*` resolving to a dictionary with the layout of the document.
-@property (readonly) BFTask *layout;
 /// Links to related resources, such as extractions, document, processed or layout.
 @property (readonly) GINIDocumentLinks *links;
 
@@ -106,69 +100,4 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
            documentManager:(GINIDocumentTaskManager *)documentManager
                      links:(GINIDocumentLinks *)links;
 
-/**
- * Gets the preview image for the given page.
- *
- * @param size              The size of the rendered preview. Please notice that those sizes are the maximum sizes of the
- *                          renderings, the actual image can have smaller dimensions.
- *
- * @param page              The page for which the preview is rendered. Please notice that only the first 10 pages of a
- *                          document are processed by the Gini API.
- */
-- (BFTask *)previewWithSize:(GiniApiPreviewSize)size forPage:(NSUInteger)page;
-
-/**
- * Gets the preview image for the given page.
- *
- * @param size                  The size of the rendered preview. Please notice that those sizes are the maximum sizes of the
- *                              renderings, the actual image can have smaller dimensions.
- * @param page                  The page for which the preview is rendered. Please notice that only the first 10 pages of a
- *                              document are processed by the Gini API.
- * @param cancellationToken     Cancellation token used to cancel the current task.
- *
- */
-- (BFTask *)previewWithSize:(GiniApiPreviewSize)size forPage:(NSUInteger)page
-          cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Gets the extractions from the document.
- *
- */
-- (BFTask *)getExtractions;
-
-/**
- * Gets the extractions from the document.
- *
- * @param cancellationToken     Cancellation token used to cancel the current task.
- *
- */
-- (BFTask *)getExtractionsWithCancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Gets the candidates from the document.
- *
- */
-- (BFTask *)getCandidates;
-
-/**
- * Gets the candidates from the document.
- *
- * @param cancellationToken     Cancellation token used to cancel the current task.
- *
- */
-- (BFTask *)getCandidatesWithCancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Gets the layout from the document.
- *
- */
-- (BFTask *)getLayout;
-
-/**
- * Gets the layout from the document.
- *
- * @param cancellationToken     Cancellation token used to cancel the current task.
- *
- */
-- (BFTask *)getLayoutWithCancellationToken:(BFCancellationToken *)cancellationToken;
 @end

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -34,7 +34,9 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
     /// A text document.
     GiniDocumentSourceClassificationText,
     /// A scanned document with the ocr information on top.
-    GiniDocumentSourceClassificationSandwich
+    GiniDocumentSourceClassificationSandwich,
+    /// A composite document created by one or several partial documents
+    GiniDocumentSourceClassificationComposite
 };
 
 /**
@@ -59,7 +61,7 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 /// (Optional) Array containing the path of every parent
 @property (readonly) NSArray<NSString *> *parents;
 /// (Optional) Array containing the path of every partial document
-@property (readonly) NSArray<NSString *> *partialdocuments;
+@property (readonly) NSArray<NSString *> *partialDocuments;
 
 
 /**

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -62,9 +62,8 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  *
  * @param apiResponse       A dictionary containing the document information. Usually the response of the Gini API.
  *
- * @param documentManager   The document manager instance that is used to communicate with the Gini API.
  */
-+ (instancetype)documentFromAPIResponse:(NSDictionary *)apiResponse withDocumentManager:(GINIDocumentTaskManager *)documentManager;
++ (instancetype)documentFromAPIResponse:(NSDictionary *)apiResponse;
 
 /**
  * The designated initializer.
@@ -73,14 +72,11 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  * @param state                 The document's state.
  * @param pageCount             The number of pages of the document.
  * @param sourceClassification  The document's source classification.
- * @param documentManager       The document manager that is used to get the additional data, e.g. for the `extractions`
- *                              and `layout` property.
  */
 - (instancetype)initWithId:(NSString *)documentId
                      state:(GiniDocumentState)state
                  pageCount:(NSUInteger)pageCount
-      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
-           documentManager:(GINIDocumentTaskManager *)documentManager;
+      sourceClassification:(GiniDocumentSourceClassification)sourceClassification;
 
 /**
  * The designated initializer.
@@ -89,15 +85,12 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  * @param state                 The document's state.
  * @param pageCount             The number of pages of the document.
  * @param sourceClassification  The document's source classification.
- * @param documentManager       The document manager that is used to get the additional data, e.g. for the `extractions`
- *                              and `layout` property.
  * @param links                 The document list of related resources (extractions, document, processed or layout).
  */
 - (instancetype)initWithId:(NSString *)documentId
                      state:(GiniDocumentState)state
                  pageCount:(NSUInteger)pageCount
       sourceClassification:(GiniDocumentSourceClassification)sourceClassification
-           documentManager:(GINIDocumentTaskManager *)documentManager
                      links:(GINIDocumentLinks *)links;
 
 @end

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -56,6 +56,11 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 @property GiniDocumentSourceClassification sourceClassification;
 /// Links to related resources, such as extractions, document, processed or layout.
 @property (readonly) GINIDocumentLinks *links;
+/// (Optional) Array containing the path of every parent
+@property (readonly) NSArray<NSString *> *parents;
+/// (Optional) Array containing the path of every partial document
+@property (readonly) NSArray<NSString *> *partialdocuments;
+
 
 /**
  * Factory to create a new document.
@@ -72,11 +77,13 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  * @param state                 The document's state.
  * @param pageCount             The number of pages of the document.
  * @param sourceClassification  The document's source classification.
+ * @param links                 The document list of related resources (extractions, document, processed or layout).
  */
 - (instancetype)initWithId:(NSString *)documentId
                      state:(GiniDocumentState)state
                  pageCount:(NSUInteger)pageCount
-      sourceClassification:(GiniDocumentSourceClassification)sourceClassification;
+      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
+                     links:(GINIDocumentLinks *)links;
 
 /**
  * The designated initializer.
@@ -86,11 +93,15 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
  * @param pageCount             The number of pages of the document.
  * @param sourceClassification  The document's source classification.
  * @param links                 The document list of related resources (extractions, document, processed or layout).
+ * @param parents               (Optional) Array containing the path of every parent
+ * @param partialDocuments      (Optional) Array containing the path of every partial document
  */
 - (instancetype)initWithId:(NSString *)documentId
                      state:(GiniDocumentState)state
                  pageCount:(NSUInteger)pageCount
       sourceClassification:(GiniDocumentSourceClassification)sourceClassification
-                     links:(GINIDocumentLinks *)links;
+                     links:(GINIDocumentLinks *)links
+                   parents:(NSArray<NSString *> *)parents
+          partialDocuments:(NSArray<NSString *> *)partialDocuments;
 
 @end

--- a/Gini-iOS-SDK/GINIDocument.h
+++ b/Gini-iOS-SDK/GINIDocument.h
@@ -62,6 +62,12 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
 @property (readonly) NSArray<NSString *> *parents;
 /// (Optional) Array containing the path of every partial document
 @property (readonly) NSArray<NSString *> *partialDocuments;
+/// A `BFTask*` resolving to a mapping with extractions (extraction name as key).
+@property (readonly) BFTask *extractions __attribute__((unavailable("use `GINIDocumentTaskManager.getExtractionsForDocument:` method instead")));
+/// A `BFTask*` resolving to a mapping with the candidates (extraction entity as key).
+@property (readonly) BFTask *candidates __attribute__((unavailable("use `GINIDocumentTaskManager.getCandidatesForDocument:` method instead")));
+/// A `BFTask*` resolving to a dictionary with the layout of the document.
+@property (readonly) BFTask *layout __attribute__((unavailable("use `GINIDocumentTaskManager.getLayoutForDocument:` method instead")));
 
 
 /**
@@ -105,5 +111,17 @@ typedef NS_ENUM(NSUInteger, GiniDocumentSourceClassification) {
                      links:(GINIDocumentLinks *)links
                    parents:(NSArray<NSString *> *)parents
           partialDocuments:(NSArray<NSString *> *)partialDocuments;
+
+/**
+ * Gets the preview image for the given page.
+ *
+ * @param size              The size of the rendered preview. Please notice that those sizes are the maximum sizes of the
+ *                          renderings, the actual image can have smaller dimensions.
+ *
+ * @param page              The page for which the preview is rendered. Please notice that only the first 10 pages of a
+ *                          document are processed by the Gini API.
+ */
+- (BFTask *)previewWithSize:(GiniApiPreviewSize)size
+                    forPage:(NSUInteger)page __attribute__((unavailable("use `GINIDocumentTaskManager.getPreviewForPage:ofDocument:withSize:` method instead")));
 
 @end

--- a/Gini-iOS-SDK/GINIDocument.m
+++ b/Gini-iOS-SDK/GINIDocument.m
@@ -56,8 +56,17 @@
     }
 
     NSUInteger pageCount = [apiResponse[@"pageCount"] unsignedIntValue];
-
-    GINIDocument *document = [[GINIDocument alloc] initWithId:documentId state:documentState pageCount:pageCount sourceClassification:(GiniDocumentSourceClassification) sourceClassification documentManager:documentManager];
+    NSDictionary *linksDict = [apiResponse valueForKey:@"_links"];
+    GINIDocumentLinks *links = [[GINIDocumentLinks alloc] initWithDocumentURL:linksDict[@"document"]
+                                                               extractionsURL:linksDict[@"extractions"]
+                                                                    layoutURL:linksDict[@"layout"] 
+                                                                 processedURL:linksDict[@"processed"]];
+    GINIDocument *document = [[GINIDocument alloc] initWithId:documentId
+                                                        state:documentState
+                                                    pageCount:pageCount
+                                         sourceClassification:(GiniDocumentSourceClassification) sourceClassification
+                                              documentManager:documentManager
+                                                        links:links];
     document.filename = [apiResponse valueForKey:@"name"];
     document.creationDate = [NSDate dateWithTimeIntervalSince1970:floor([[apiResponse valueForKey:@"creationDate"] doubleValue] / 1000)];
 
@@ -68,7 +77,12 @@
 
 - (instancetype)initWithId:(NSString *)documentId state:(GiniDocumentState)state pageCount:(NSUInteger)pageCount sourceClassification:(GiniDocumentSourceClassification)sourceClassification documentManager:(GINIDocumentTaskManager *)documentManager {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    return [self initWithId:documentId state:state pageCount:pageCount sourceClassification:sourceClassification documentManager:documentManager links:nil];
+}
 
+- (instancetype)initWithId:(NSString *)documentId state:(GiniDocumentState)state pageCount:(NSUInteger)pageCount sourceClassification:(GiniDocumentSourceClassification)sourceClassification documentManager:(GINIDocumentTaskManager *)documentManager links:(GINIDocumentLinks *)links {
+    NSParameterAssert([documentId isKindOfClass:[NSString class]]);
+    
     self = [super init];
     if (self) {
         _documentId = documentId;
@@ -76,7 +90,9 @@
         _documentTaskManager = documentManager;
         _sourceClassification = sourceClassification;
         _pageCount = pageCount;
+        _links = links;
     }
+    
     return self;
 }
 

--- a/Gini-iOS-SDK/GINIDocument.m
+++ b/Gini-iOS-SDK/GINIDocument.m
@@ -48,6 +48,8 @@
         sourceClassification = GiniDocumentSourceClassificationText;
     } else if ([classification isEqualToString:@"SANDWICH"]) {
         sourceClassification = GiniDocumentSourceClassificationSandwich;
+    } else if ([classification isEqualToString:@"COMPOSITE"]) {
+        sourceClassification = GiniDocumentSourceClassificationComposite;
     } else {
         NSLog(@"Unknown document source classification: %@", classification);
         return nil;
@@ -62,7 +64,7 @@
                                                                  processedURL:linksDict[@"processed"]];
     
     NSArray<NSString *> *parents = [apiResponse valueForKey:@"parents"];
-    NSArray<NSString *> *partialDocuments = [apiResponse valueForKey:@"partialdocuments"];
+    NSArray<NSString *> *partialDocuments = [apiResponse valueForKey:@"partialDocuments"];
     
     GINIDocument *document = [[GINIDocument alloc] initWithId:documentId
                                                         state:documentState
@@ -111,7 +113,7 @@
         _pageCount = pageCount;
         _links = links;
         _parents = parents;
-        _partialdocuments = partialDocuments;
+        _partialDocuments = partialDocuments;
     }
     
     return self;

--- a/Gini-iOS-SDK/GINIDocument.m
+++ b/Gini-iOS-SDK/GINIDocument.m
@@ -17,7 +17,7 @@
 
 }
 
-+ (instancetype)documentFromAPIResponse:(NSDictionary *)apiResponse withDocumentManager:(GINIDocumentTaskManager *)documentManager{
++ (instancetype)documentFromAPIResponse:(NSDictionary *)apiResponse {
     NSString *documentId = apiResponse[@"id"];
     // Documents must have an ID.
     if (!documentId) {
@@ -63,7 +63,6 @@
                                                         state:documentState
                                                     pageCount:pageCount
                                          sourceClassification:(GiniDocumentSourceClassification) sourceClassification
-                                              documentManager:documentManager
                                                         links:links];
     document.filename = [apiResponse valueForKey:@"name"];
     document.creationDate = [NSDate dateWithTimeIntervalSince1970:floor([[apiResponse valueForKey:@"creationDate"] doubleValue] / 1000)];

--- a/Gini-iOS-SDK/GINIDocument.m
+++ b/Gini-iOS-SDK/GINIDocument.m
@@ -54,16 +54,23 @@
     }
 
     NSUInteger pageCount = [apiResponse[@"pageCount"] unsignedIntValue];
+    
     NSDictionary *linksDict = [apiResponse valueForKey:@"_links"];
     GINIDocumentLinks *links = [[GINIDocumentLinks alloc] initWithDocumentURL:linksDict[@"document"]
                                                                extractionsURL:linksDict[@"extractions"]
                                                                     layoutURL:linksDict[@"layout"] 
                                                                  processedURL:linksDict[@"processed"]];
+    
+    NSArray<NSString *> *parents = [apiResponse valueForKey:@"parents"];
+    NSArray<NSString *> *partialDocuments = [apiResponse valueForKey:@"partialdocuments"];
+    
     GINIDocument *document = [[GINIDocument alloc] initWithId:documentId
                                                         state:documentState
                                                     pageCount:pageCount
                                          sourceClassification:(GiniDocumentSourceClassification) sourceClassification
-                                                        links:links];
+                                                        links:links
+                                                      parents:parents
+                                             partialDocuments:partialDocuments];
     document.filename = [apiResponse valueForKey:@"name"];
     document.creationDate = [NSDate dateWithTimeIntervalSince1970:floor([[apiResponse valueForKey:@"creationDate"] doubleValue] / 1000)];
 
@@ -72,12 +79,28 @@
 
 #pragma mark - Initializer
 
-- (instancetype)initWithId:(NSString *)documentId state:(GiniDocumentState)state pageCount:(NSUInteger)pageCount sourceClassification:(GiniDocumentSourceClassification)sourceClassification {
+- (instancetype)initWithId:(NSString *)documentId
+                     state:(GiniDocumentState)state
+                 pageCount:(NSUInteger)pageCount
+      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
+                     links:(GINIDocumentLinks *)links {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
-    return [self initWithId:documentId state:state pageCount:pageCount sourceClassification:sourceClassification links:nil];
+    return [self initWithId:documentId
+                      state:state
+                  pageCount:pageCount
+       sourceClassification:sourceClassification
+                      links:links
+                    parents:nil
+           partialDocuments:nil];
 }
 
-- (instancetype)initWithId:(NSString *)documentId state:(GiniDocumentState)state pageCount:(NSUInteger)pageCount sourceClassification:(GiniDocumentSourceClassification)sourceClassification links:(GINIDocumentLinks *)links {
+- (instancetype)initWithId:(NSString *)documentId
+                     state:(GiniDocumentState)state
+                 pageCount:(NSUInteger)pageCount
+      sourceClassification:(GiniDocumentSourceClassification)sourceClassification
+                     links:(GINIDocumentLinks *)links
+                   parents:(NSArray<NSString *> *)parents
+          partialDocuments:(NSArray<NSString *> *)partialDocuments {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
     
     self = [super init];
@@ -87,6 +110,8 @@
         _sourceClassification = sourceClassification;
         _pageCount = pageCount;
         _links = links;
+        _parents = parents;
+        _partialdocuments = partialDocuments;
     }
     
     return self;

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -180,6 +180,28 @@
          cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
+ * Deletes document with the given ID.
+ *
+ * @param documentId               The document's id.
+ * @param cancellationToken        Cancellation token used to cancel the current task.
+ *
+ * @returns                        A `BFTask*` with `nil` as result when the document has been deleted.
+ */
+- (BFTask *)deleteDocumentWithId:(NSString *)documentId
+               cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Deletes partial document with the given ID.
+ *
+ * @param documentId               The document's id.
+ * @param cancellationToken        Cancellation token used to cancel the current task.
+ *
+ * @returns                        A `BFTask*` with `nil` as result when the document has been deleted.
+ */
+- (BFTask *)deletePartialDocumentWithId:(NSString *)documentId
+                      cancellationToken:(BFCancellationToken *) cancellationToken;
+
+/**
  * Continually checks the document status until the document is fully processed.
  *
  * If the document is in the error state, this method also does not continue polling, but the extractions won't be

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -25,346 +25,456 @@
  * into the usage of tasks in the Gini SDK.
  */
 @interface GINIDocumentTaskManager : NSObject
-
-/**
- * Factory to create a new instance of the document task manager.
- *
- * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
- */
+    
+    /**
+     * Factory to create a new instance of the document task manager.
+     *
+     * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
+     */
 + (instancetype)documentTaskManagerWithAPIManager:(GINIAPIManager *)apiManager;
-
-/**
- * The designated initializer.
- *
- * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
- */
+    
+    /**
+     * The designated initializer.
+     *
+     * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
+     */
 - (instancetype)initWithAPIManager:(GINIAPIManager *)apiManager;
-
-/**
- * The time in seconds between HTTP requests when polling documents.
- */
-@property NSUInteger pollingInterval;
-
-/**
- * Gets the document with the given id.
- *
- * @param documentId    The document's unique identifier.
- *
- * @returns             A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
- */
+    
+    /**
+     * The time in seconds between HTTP requests when polling documents.
+     */
+    @property NSUInteger pollingInterval;
+    
+    /**
+     * Gets the document with the given id.
+     *
+     * @param documentId    The document's unique identifier.
+     *
+     * @returns             A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
+     */
 - (BFTask *)getDocumentWithId:(NSString *)documentId;
-
-/**
- * Gets the document with the given id.
- *
- * @param documentId            The document's unique identifier.
- * @param cancellationToken     Cancellation token used to cancel the current task.
- *
- * @returns                     A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
- */
+    
+    /**
+     * Gets the document with the given id.
+     *
+     * @param documentId            The document's unique identifier.
+     * @param cancellationToken     Cancellation token used to cancel the current task.
+     *
+     * @returns                     A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
+     */
 - (BFTask *)getDocumentWithId:(NSString *)documentId
             cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Creates a new document from the given image.
- *
- * @param fileName      The file name of the document.
- * @param image         An image representing the document.
- *
- * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
- *                      Please notice that it is very unlikely that the created document is already fully processed, so
- *                      the extractions may not yet exist.
- */
+    
+    /**
+     * Creates a new document from the given image.
+     *
+     * @param fileName      The file name of the document.
+     * @param image         An image representing the document.
+     *
+     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                      Please notice that it is very unlikely that the created document is already fully processed, so
+     *                      the extractions may not yet exist.
+     */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image;
-
-/**
- * Creates a new document from the given image.
- *
- * @param fileName              The file name of the document.
- * @param image                 An image representing the document.
- * @param cancellationToken     Cancellation token used to cancel the current task.
- *
- * @returns                     A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
- *                              Please notice that it is very unlikely that the created document is already fully processed, so
- *                              the extractions may not yet exist.
- */
+    
+    /**
+     * Creates a new document from the given image.
+     *
+     * @param fileName              The file name of the document.
+     * @param image                 An image representing the document.
+     * @param cancellationToken     Cancellation token used to cancel the current task.
+     *
+     * @returns                     A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                              Please notice that it is very unlikely that the created document is already fully processed, so
+     *                              the extractions may not yet exist.
+     */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
                      cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
- * processing is optimized in many ways.
- *
- * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
- * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- *
- * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
- * knows the doctype.
- */
+    
+    /**
+     * Creates a new document from the given image.
+     *
+     * @param fileName                  The file name of the document.
+     * @param image                     An image representing the document.
+     * @param isPartialDocument         The document is part of a multi document
+     *
+     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                      Please notice that it is very unlikely that the created document is already fully processed, so
+     *                      the extractions may not yet exist.
+     */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                     isPartialDocument:(BOOL)isPartialDocument;
+    
+    /**
+     * Creates a new document from the given image.
+     *
+     * @param fileName                  The file name of the document.
+     * @param image                     An image representing the document.
+     * @param isPartialDocument         The document is part of a multi document
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     *
+     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                      Please notice that it is very unlikely that the created document is already fully processed, so
+     *                      the extractions may not yet exist.
+     */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                     isPartialDocument:(BOOL)isPartialDocument
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
+    
+    /**
+     * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
+     * processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
+     * knows the doctype.
+     */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
                                docType:(NSString *)docType;
-
-/**
- * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
- * processing is optimized in many ways.
- *
- * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
- * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- *
- * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
- * knows the doctype.
- */
+    
+    /**
+     * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
+     * processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
+     * knows the doctype.
+     */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
                                docType:(NSString *)docType
                      cancellationToken:(BFCancellationToken *)cancellationToken;
+    
+    /**
+     * Creates a new document with the given `doctype` from the given image and indicating is it is a partial document.
+     * By providing the doctype, Gini's document processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
+     * knows the doctype.
+     */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                               docType:(NSString *)docType
+                     isPartialDocument:(BOOL)isPartialDocument;
 
-/**
- * Creates a new document with the given `doctype` from the given data. 
- * Data can be in the format of a PDF, UTF-8 text or image representation.
- * By providing the doctype, Gini's document processing is optimized in many ways.
- *
- * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
- * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- *
- * @param fileName      The file name of the document.
- * @param data          Data representing the document.
- * @param docType       The doctype hint for the document.
- *
- * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
- *                      Please notice that it is very unlikely that the created document is already fully processed, so
- *                      the extractions may not yet exist.
- */
+    /**
+     * Creates a new document with the given `doctype` from the given image and indicating is it is a partial document.
+     * By providing the doctype, Gini's document processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
+     * knows the doctype.
+     */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                               docType:(NSString *)docType
+                     isPartialDocument:(BOOL)isPartialDocument
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
+    
+    /**
+     * Creates a new document with the given `doctype` from the given data.
+     * Data can be in the format of a PDF, UTF-8 text or image representation.
+     * By providing the doctype, Gini's document processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @param fileName      The file name of the document.
+     * @param data          Data representing the document.
+     * @param docType       The doctype hint for the document.
+     *
+     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                      Please notice that it is very unlikely that the created document is already fully processed, so
+     *                      the extractions may not yet exist.
+     */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType;
-
-/**
- * Creates a new document with the given `doctype` from the given data.
- * Data can be in the format of a PDF, UTF-8 text or image representation.
- * By providing the doctype, Gini's document processing is optimized in many ways.
- *
- * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
- * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- *
- * @param fileName                  The file name of the document.
- * @param data                      Data representing the document.
- * @param docType                   The doctype hint for the document.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- *
- * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
- *                                  Please notice that it is very unlikely that the created document is already fully processed, so
- *                                  the extractions may not yet exist.
- */
+    
+    /**
+     * Creates a new document with the given `doctype` from the given data.
+     * Data can be in the format of a PDF, UTF-8 text or image representation.
+     * By providing the doctype, Gini's document processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @param fileName                  The file name of the document.
+     * @param data                      Data representing the document.
+     * @param docType                   The doctype hint for the document.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     *
+     * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                                  Please notice that it is very unlikely that the created document is already fully processed, so
+     *                                  the extractions may not yet exist.
+     */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType
                      cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Saves updates on the extractions.
- *
- * Updating extractions is called "Submitting feedback" in the Gini API documentation.
- *
- * @param document      The document.
- */
+    
+    
+    /**
+     * Creates a new document with the given `doctype` from the given data.
+     * Data can be in the format of a PDF, UTF-8 text or image representation.
+     * By providing the doctype, Gini's document processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @param fileName                  The file name of the document.
+     * @param data                      Data representing the document.
+     * @param docType                   The doctype hint for the document.
+     * @param isPartialDocument         The document is part of a multi document
+     *
+     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                      Please notice that it is very unlikely that the created document is already fully processed, so
+     *                      the extractions may not yet exist.
+     */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                     isPartialDocument:(BOOL)isPartialDocument;
+    
+    /**
+     * Creates a new document with the given `doctype` from the given data.
+     * Data can be in the format of a PDF, UTF-8 text or image representation.
+     * By providing the doctype, Gini's document processing is optimized in many ways.
+     *
+     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+     *
+     * @param fileName                  The file name of the document.
+     * @param data                      Data representing the document.
+     * @param docType                   The doctype hint for the document.
+     * @param isPartialDocument         The document is part of a multi document
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     *
+     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+     *                      Please notice that it is very unlikely that the created document is already fully processed, so
+     *                      the extractions may not yet exist.
+     */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                     isPartialDocument:(BOOL)isPartialDocument
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
+    
+    /**
+     * Saves updates on the extractions.
+     *
+     * Updating extractions is called "Submitting feedback" in the Gini API documentation.
+     *
+     * @param document      The document.
+     */
 - (BFTask *)updateDocument:(GINIDocument *)document;
-
-/**
- * Saves updates on the extractions.
- *
- * Updating extractions is called "Submitting feedback" in the Gini API documentation.
- *
- * @param document                  The document.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- */
+    
+    /**
+     * Saves updates on the extractions.
+     *
+     * Updating extractions is called "Submitting feedback" in the Gini API documentation.
+     *
+     * @param document                  The document.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     */
 - (BFTask *)updateDocument:(GINIDocument *)document
          cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Deletes the given document.
- *
- * @param document      The document that will be deleted.
- */
+    
+    /**
+     * Deletes the given document.
+     *
+     * @param document      The document that will be deleted.
+     */
 - (BFTask *)deleteDocument:(GINIDocument *)document;
-
-/**
- * Deletes the given document.
- *
- * @param document                  The document that will be deleted.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- */
+    
+    /**
+     * Deletes the given document.
+     *
+     * @param document                  The document that will be deleted.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     */
 - (BFTask *)deleteDocument:(GINIDocument *)document
          cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Continually checks the document status until the document is fully processed.
- *
- * If the document is in the error state, this method also does not continue polling, but the extractions won't be
- * available.
- *
- * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
- * `pollingInterval` property of this class.
- *
- * @warning             This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
- *                      document. Please notice that the task's result will not be the same document object as the given
- *                      document instance and the given document instance will not be updated with the polled results!
- *
- * @param document      The document that will be polled.
- */
+    
+    /**
+     * Continually checks the document status until the document is fully processed.
+     *
+     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+     * available.
+     *
+     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+     * `pollingInterval` property of this class.
+     *
+     * @warning             This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
+     *                      document. Please notice that the task's result will not be the same document object as the given
+     *                      document instance and the given document instance will not be updated with the polled results!
+     *
+     * @param document      The document that will be polled.
+     */
 - (BFTask *)pollDocument:(GINIDocument *)document;
-
-/**
- * Continually checks the document status until the document is fully processed.
- *
- * If the document is in the error state, this method also does not continue polling, but the extractions won't be
- * available.
- *
- * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
- * `pollingInterval` property of this class.
- *
- * @warning                         This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
- *                                  document. Please notice that the task's result will not be the same document object as the given
- *                                  document instance and the given document instance will not be updated with the polled results!
- *
- * @param document                  The document that will be polled.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- */
+    
+    /**
+     * Continually checks the document status until the document is fully processed.
+     *
+     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+     * available.
+     *
+     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+     * `pollingInterval` property of this class.
+     *
+     * @warning                         This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
+     *                                  document. Please notice that the task's result will not be the same document object as the given
+     *                                  document instance and the given document instance will not be updated with the polled results!
+     *
+     * @param document                  The document that will be polled.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     */
 - (BFTask *)pollDocument:(GINIDocument *)document
        cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
-* Continually checks the document status until the document is fully processed.
-*
-* If the document is in the error state, this method also does not continue polling, but the extractions won't be
-* available.
-*
-* To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
-* `pollingInterval` property of this class.
-*
-* @param documentId     The unique identifier of the document which will be polled.
-*/
+    
+    /**
+     * Continually checks the document status until the document is fully processed.
+     *
+     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+     * available.
+     *
+     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+     * `pollingInterval` property of this class.
+     *
+     * @param documentId     The unique identifier of the document which will be polled.
+     */
 - (BFTask *)pollDocumentWithId:(NSString *)documentId;
-
-/**
- * Continually checks the document status until the document is fully processed.
- *
- * If the document is in the error state, this method also does not continue polling, but the extractions won't be
- * available.
- *
- * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
- * `pollingInterval` property of this class.
- *
- * @param documentId                The unique identifier of the document which will be polled.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- */
+    
+    /**
+     * Continually checks the document status until the document is fully processed.
+     *
+     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+     * available.
+     *
+     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+     * `pollingInterval` property of this class.
+     *
+     * @param documentId                The unique identifier of the document which will be polled.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     */
 - (BFTask *)pollDocumentWithId:(NSString *)documentId
              cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Gets the preview image for the given page of the given document.
- *
- * @param page          The page number of the document (starting from 1, not 0!).
- * @param document      The document.
- * @param size          The size in which the document will be rendered. Please notice that this is the maximum size,
- *                      meaning that the images dimensions will not exceeding this limit but the rendered image can
- *                      actually have a little smaller dimensions.
- */
+    
+    /**
+     * Gets the preview image for the given page of the given document.
+     *
+     * @param page          The page number of the document (starting from 1, not 0!).
+     * @param document      The document.
+     * @param size          The size in which the document will be rendered. Please notice that this is the maximum size,
+     *                      meaning that the images dimensions will not exceeding this limit but the rendered image can
+     *                      actually have a little smaller dimensions.
+     */
 - (BFTask *)getPreviewForPage:(NSUInteger)page
                    ofDocument:(GINIDocument *)document
                      withSize:(GiniApiPreviewSize)size;
-
-/**
- * Gets the preview image for the given page of the given document.
- *
- * @param page                      The page number of the document (starting from 1, not 0!).
- * @param document                  The document.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- * @param size                      The size in which the document will be rendered. Please notice that this is the maximum size,
- *                                  meaning that the images dimensions will not exceeding this limit but the rendered image can
- *                                  actually have a little smaller dimensions.
- */
+    
+    /**
+     * Gets the preview image for the given page of the given document.
+     *
+     * @param page                      The page number of the document (starting from 1, not 0!).
+     * @param document                  The document.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     * @param size                      The size in which the document will be rendered. Please notice that this is the maximum size,
+     *                                  meaning that the images dimensions will not exceeding this limit but the rendered image can
+     *                                  actually have a little smaller dimensions.
+     */
 - (BFTask *)getPreviewForPage:(NSUInteger)page
                    ofDocument:(GINIDocument *)document
                      withSize:(GiniApiPreviewSize)size
             cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Gets the extractions for the given document.
- *
- * @param document      The document.
- */
+    
+    /**
+     * Gets the extractions for the given document.
+     *
+     * @param document      The document.
+     */
 - (BFTask *)getExtractionsForDocument:(GINIDocument *)document;
-
-/**
- * Gets the extractions for the given document.
- *
- * @param document                  The document.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- */
+    
+    /**
+     * Gets the extractions for the given document.
+     *
+     * @param document                  The document.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     */
 - (BFTask *)getExtractionsForDocument:(GINIDocument *)document
                     cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
-* Gets the extractions for the specific document, including the incubation extractions (see
-* http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
-*
-* @param document       The document.
-*/
+    
+    /**
+     * Gets the extractions for the specific document, including the incubation extractions (see
+     * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
+     *
+     * @param document       The document.
+     */
 - (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document;
-
-/**
- * Gets the extractions for the specific document, including the incubation extractions (see
- * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
- *
- * @param document                  The document.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- */
+    
+    /**
+     * Gets the extractions for the specific document, including the incubation extractions (see
+     * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
+     *
+     * @param document                  The document.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     */
 - (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document
                              cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Saves the new values for the given extraction of the given document.
- *
- * Please note that updating an extraction is called "Submitting feedback" in the Gini API documentation.
- *
- * @param extraction    The extraction.
- * @param document      The document.
- */
+    
+    /**
+     * Saves the new values for the given extraction of the given document.
+     *
+     * Please note that updating an extraction is called "Submitting feedback" in the Gini API documentation.
+     *
+     * @param extraction    The extraction.
+     * @param document      The document.
+     */
 - (BFTask *)updateExtraction:(GINIExtraction *)extraction forDocument:(GINIDocument *)document;
-
-/**
- * Gets the layout for the given document.
- *
- * @param document      The document.
- */
+    
+    /**
+     * Gets the layout for the given document.
+     *
+     * @param document      The document.
+     */
 - (BFTask *)getLayoutForDocument:(GINIDocument *)document;
-
-/**
- * Gets the layout for the given document.
- *
- * @param document                  The document.
- * @param cancellationToken         Cancellation token used to cancel the current task.
- */
+    
+    /**
+     * Gets the layout for the given document.
+     *
+     * @param document                  The document.
+     * @param cancellationToken         Cancellation token used to cancel the current task.
+     */
 - (BFTask *)getLayoutForDocument:(GINIDocument *)document
                cancellationToken:(BFCancellationToken *)cancellationToken;
-
-/**
- * Report an error for a specific document. If the processing result for a document was not satisfactory (e.g.
- * extractions where empty or incorrect), you can create an error report for a document. This allows Gini to analyze and
- * correct the problem that was found. The returned errorId can be used to refer to the reported error towards the Gini
- * support.
- *
- * @warning The owner of this document must agree that Gini can use this document for debugging and error analysis.
- *
- * @param document          The document for which the error is reported.
- * @param summary           A summary for the error (optional).
- * @param description       A detailed description for the error (optional).
- */
+    
+    /**
+     * Report an error for a specific document. If the processing result for a document was not satisfactory (e.g.
+     * extractions where empty or incorrect), you can create an error report for a document. This allows Gini to analyze and
+     * correct the problem that was found. The returned errorId can be used to refer to the reported error towards the Gini
+     * support.
+     *
+     * @warning The owner of this document must agree that Gini can use this document for debugging and error analysis.
+     *
+     * @param document          The document for which the error is reported.
+     * @param summary           A summary for the error (optional).
+     * @param description       A detailed description for the error (optional).
+     */
 - (BFTask *)errorReportForDocument:(GINIDocument *)document
                            summary:(NSString *)summary
                        description:(NSString *)description;
-@end
+    @end

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -156,19 +156,11 @@
  *
  * Updating extractions is called "Submitting feedback" in the Gini API documentation.
  *
- * @param document      The document.
- */
-- (BFTask *)updateDocument:(GINIDocument *)document;
-
-/**
- * Saves updates on the extractions.
- *
- * Updating extractions is called "Submitting feedback" in the Gini API documentation.
- *
  * @param document                  The document.
  * @param cancellationToken         Cancellation token used to cancel the current task.
  */
 - (BFTask *)updateDocument:(GINIDocument *)document
+        updatedExtractions:(NSDictionary *)updatedExtractions
          cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -133,70 +133,6 @@
                                docType:(NSString *)docType
                      cancellationToken:(BFCancellationToken *)cancellationToken;
 
-
-/**
- * Creates a new document with the given `doctype` from the given data.
- * Data can be in the format of a PDF, UTF-8 text or image representation.
- * By providing the doctype, Gini's document processing is optimized in many ways.
- *
- * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
- * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- *
- * @param fileName                  The file name of the document.
- * @param data                      Data representing the document.
- * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- * @param isPartialDocument         The document is part of a multi document
- *
- * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
- *                      Please notice that it is very unlikely that the created document is already fully processed, so
- *                      the extractions may not yet exist.
- */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                              fromData:(NSData *)data
-                               docType:(NSString *)docType
-                     isPartialDocument:(BOOL)isPartialDocument;
-
-/**
- * Creates a new document with the given `doctype` from the given data.
- * Data can be in the format of a PDF, UTF-8 text or image representation.
- * By providing the doctype, Gini's document processing is optimized in many ways.
- *
- * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
- * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- *
- * @param fileName                  The file name of the document.
- * @param data                      Data representing the document.
- * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- * @param isPartialDocument         The document is part of a multi document
- * @param cancellationToken         Cancellation token used to cancel the current task.
- *
- * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
- *                      Please notice that it is very unlikely that the created document is already fully processed, so
- *                      the extractions may not yet exist.
- */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                              fromData:(NSData *)data
-                               docType:(NSString *)docType
-                     isPartialDocument:(BOOL)isPartialDocument
-                     cancellationToken:(BFCancellationToken *)cancellationToken;
-/**
- * Creates a new multi whatever document with the given subdocuments urls.
- *
- * @param subDocumentsURLs          Array containing the URL for each sub document.
- * @param fileName                  The file name of the document.
- * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- * @param cancellationToken         Cancellation token used to cancel the current task.
- *
- * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created multi whatever document.
- *                      Please notice that it is very unlikely that the created document is already fully processed, so
- *                      the extractions may not yet exist.
- */
-
-- (BFTask *)createMultipageDocumentWithSubDocumentsURLs:(NSArray<NSURL*>*)subDocumentsURLs
-                                               fileName:(NSString *)fileName
-                                                docType:(NSString *)docType
-                                      cancellationToken:(BFCancellationToken *)cancellationToken;
-
 /**
  * Saves updates on the extractions.
  *
@@ -339,6 +275,22 @@
  * @param cancellationToken         Cancellation token used to cancel the current task.
  */
 - (BFTask *)getExtractionsForDocument:(GINIDocument *)document
+                    cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Creates a new multi whatever document with the given subdocuments urls.
+ *
+ * @param subDocumentsURLs          Array containing the URL for each sub document.
+ * @param fileName                  The file name of the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created multi whatever document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
+
+- (BFTask *)getExtractionsForDocuments:(NSArray<GINIDocument*>*)documents
                     cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -134,6 +134,24 @@
                      cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
+ * Creates a new composite document
+ *
+ * @param partialDocumentsURLs  Array containing the URL path for each partial document.
+ * @param fileName              The filename of the document.
+ * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
+ *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
+ *                              for a list of possibles doctypes.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
+ */
+
+- (BFTask *)createCompositeDocumentWithPartialDocumentsURLs:(NSArray<NSString*>*)partialDocumentsURLs
+                                                   fileName:(NSString *)fileName
+                                                    docType:(NSString *)docType
+                                          cancellationToken:(BFCancellationToken *) cancellationToken;
+
+/**
  * Saves updates on the extractions.
  *
  * Updating extractions is called "Submitting feedback" in the Gini API documentation.
@@ -278,20 +296,13 @@
                     cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
- * Creates a new multi whatever document with the given subdocuments urls.
+ * Gets the candidates for the given document.
  *
- * @param subDocumentsURLs          Array containing the URL for each sub document.
- * @param fileName                  The file name of the document.
- * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param document                  The document.
  * @param cancellationToken         Cancellation token used to cancel the current task.
- *
- * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created multi whatever document.
- *                      Please notice that it is very unlikely that the created document is already fully processed, so
- *                      the extractions may not yet exist.
  */
-
-- (BFTask *)getExtractionsForDocuments:(NSArray<GINIDocument*>*)documents
-                    cancellationToken:(BFCancellationToken *)cancellationToken;
+- (BFTask *)getCandidatesForDocument:(GINIDocument *)document
+                   cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Gets the extractions for the specific document, including the incubation extractions (see

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -136,7 +136,7 @@
 /**
  * Creates a new composite document
  *
- * @param partialDocumentsURLs  Array containing the URL path for each partial document.
+ * @param partialDocumentsInfo  Array containing the partial documents info (document url and additional parameters).
  * @param fileName              The filename of the document.
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
  *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
@@ -146,7 +146,7 @@
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
  */
 
-- (BFTask *)createCompositeDocumentWithPartialDocumentsURLs:(NSArray<NSString*>*)partialDocumentsURLs
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<NSDictionary<NSString *, id>*>*)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *) cancellationToken;

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -7,7 +7,6 @@
 #import <UIKit/UIKit.h>
 #import "GINIAPIManager.h"
 
-
 @class BFTask;
 @class GINIDocument;
 @class GINIExtraction;
@@ -76,54 +75,7 @@
      *                      the extractions may not yet exist.
      */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image;
-    
-    /**
-     * Creates a new document from the given image.
-     *
-     * @param fileName              The file name of the document.
-     * @param image                 An image representing the document.
-     * @param cancellationToken     Cancellation token used to cancel the current task.
-     *
-     * @returns                     A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                              Please notice that it is very unlikely that the created document is already fully processed, so
-     *                              the extractions may not yet exist.
-     */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image
-                     cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Creates a new document from the given image.
-     *
-     * @param fileName                  The file name of the document.
-     * @param image                     An image representing the document.
-     * @param isPartialDocument         The document is part of a multi document
-     *
-     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                      Please notice that it is very unlikely that the created document is already fully processed, so
-     *                      the extractions may not yet exist.
-     */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image
-                     isPartialDocument:(BOOL)isPartialDocument;
-    
-    /**
-     * Creates a new document from the given image.
-     *
-     * @param fileName                  The file name of the document.
-     * @param image                     An image representing the document.
-     * @param isPartialDocument         The document is part of a multi document
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     *
-     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                      Please notice that it is very unlikely that the created document is already fully processed, so
-     *                      the extractions may not yet exist.
-     */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image
-                     isPartialDocument:(BOOL)isPartialDocument
-                     cancellationToken:(BFCancellationToken *)cancellationToken;
+                             fromImage:(UIImage *)image __attribute__((deprecated("use createdDocumentWithFilename:fromData: methods instead")));
     
     /**
      * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
@@ -137,53 +89,7 @@
      */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
-                               docType:(NSString *)docType;
-    
-    /**
-     * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
-     * processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
-     * knows the doctype.
-     */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image
-                               docType:(NSString *)docType
-                     cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Creates a new document with the given `doctype` from the given image and indicating is it is a partial document.
-     * By providing the doctype, Gini's document processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
-     * knows the doctype.
-     */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image
-                               docType:(NSString *)docType
-                     isPartialDocument:(BOOL)isPartialDocument;
-
-    /**
-     * Creates a new document with the given `doctype` from the given image and indicating is it is a partial document.
-     * By providing the doctype, Gini's document processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
-     * knows the doctype.
-     */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image
-                               docType:(NSString *)docType
-                     isPartialDocument:(BOOL)isPartialDocument
-                     cancellationToken:(BFCancellationToken *)cancellationToken;
+                               docType:(NSString *)docType __attribute__((deprecated("use createdDocumentWithFilename:fromData: methods instead")));
     
     /**
      * Creates a new document with the given `doctype` from the given data.
@@ -195,7 +101,7 @@
      *
      * @param fileName      The file name of the document.
      * @param data          Data representing the document.
-     * @param docType       The doctype hint for the document.
+     * @param docType       The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
      *
      * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
      *                      Please notice that it is very unlikely that the created document is already fully processed, so
@@ -215,7 +121,7 @@
      *
      * @param fileName                  The file name of the document.
      * @param data                      Data representing the document.
-     * @param docType                   The doctype hint for the document.
+     * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
      * @param cancellationToken         Cancellation token used to cancel the current task.
      *
      * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
@@ -238,7 +144,7 @@
      *
      * @param fileName                  The file name of the document.
      * @param data                      Data representing the document.
-     * @param docType                   The doctype hint for the document.
+     * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
      * @param isPartialDocument         The document is part of a multi document
      *
      * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
@@ -260,7 +166,7 @@
      *
      * @param fileName                  The file name of the document.
      * @param data                      Data representing the document.
-     * @param docType                   The doctype hint for the document.
+     * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
      * @param isPartialDocument         The document is part of a multi document
      * @param cancellationToken         Cancellation token used to cancel the current task.
      *

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -75,7 +75,7 @@
  *                      the extractions may not yet exist.
  */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image __attribute__((deprecated("use createdDocumentWithFilename:fromData: methods instead")));
+                             fromImage:(UIImage *)image __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: methods instead")));
 
 /**
  * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
@@ -89,7 +89,7 @@
  */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
-                               docType:(NSString *)docType __attribute__((deprecated("use createdDocumentWithFilename:fromData: methods instead")));
+                               docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: methods instead")));
 
 /**
  * Creates a new document with the given `doctype` from the given data.
@@ -109,7 +109,7 @@
  */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
-                               docType:(NSString *)docType;
+                               docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: methods instead")));
 
 /**
  * Creates a new document with the given `doctype` from the given data.
@@ -128,10 +128,10 @@
  *                                  Please notice that it is very unlikely that the created document is already fully processed, so
  *                                  the extractions may not yet exist.
  */
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                              fromData:(NSData *)data
-                               docType:(NSString *)docType
-                     cancellationToken:(BFCancellationToken *)cancellationToken;
+- (BFTask *)createPartialDocumentWithFilename:(NSString *)fileName
+                                     fromData:(NSData *)data
+                                      docType:(NSString *)docType
+                            cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Creates a new composite document

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -6,6 +6,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "GINIAPIManager.h"
+#import "GINIPartialDocumentInfo.h"
 
 @class BFTask;
 @class GINIDocument;
@@ -146,7 +147,7 @@
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
  */
 
-- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<NSDictionary<NSString *, id>*>*)partialDocumentsInfo
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *>*)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *) cancellationToken;

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -179,6 +179,11 @@
                                docType:(NSString *)docType
                      isPartialDocument:(BOOL)isPartialDocument
                      cancellationToken:(BFCancellationToken *)cancellationToken;
+
+- (BFTask *)createMultipageDocumentWithSubDocumentURLs:(NSArray<NSURL*>*)subDocumentURLs
+                                             fileName:(NSString *)fileName
+                                              docType:(NSString *)docType
+                                    cancellationToken:(BFCancellationToken *)cancellationToken;
     
     /**
      * Saves updates on the extractions.

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -24,368 +24,380 @@
  * into the usage of tasks in the Gini SDK.
  */
 @interface GINIDocumentTaskManager : NSObject
-    
-    /**
-     * Factory to create a new instance of the document task manager.
-     *
-     * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
-     */
+
+/**
+ * Factory to create a new instance of the document task manager.
+ *
+ * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
+ */
 + (instancetype)documentTaskManagerWithAPIManager:(GINIAPIManager *)apiManager;
-    
-    /**
-     * The designated initializer.
-     *
-     * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
-     */
+
+/**
+ * The designated initializer.
+ *
+ * @param apiManager    An instance of `GINIAPIManager` which will be used to communicate with the Gini API.
+ */
 - (instancetype)initWithAPIManager:(GINIAPIManager *)apiManager;
-    
-    /**
-     * The time in seconds between HTTP requests when polling documents.
-     */
-    @property NSUInteger pollingInterval;
-    
-    /**
-     * Gets the document with the given id.
-     *
-     * @param documentId    The document's unique identifier.
-     *
-     * @returns             A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
-     */
+
+/**
+ * The time in seconds between HTTP requests when polling documents.
+ */
+@property NSUInteger pollingInterval;
+
+/**
+ * Gets the document with the given id.
+ *
+ * @param documentId    The document's unique identifier.
+ *
+ * @returns             A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
+ */
 - (BFTask *)getDocumentWithId:(NSString *)documentId;
-    
-    /**
-     * Gets the document with the given id.
-     *
-     * @param documentId            The document's unique identifier.
-     * @param cancellationToken     Cancellation token used to cancel the current task.
-     *
-     * @returns                     A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
-     */
+
+/**
+ * Gets the document with the given id.
+ *
+ * @param documentId            The document's unique identifier.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A `BFTask` that will resolve to a `GINIDocument` instance representing the document.
+ */
 - (BFTask *)getDocumentWithId:(NSString *)documentId
             cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Creates a new document from the given image.
-     *
-     * @param fileName      The file name of the document.
-     * @param image         An image representing the document.
-     *
-     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                      Please notice that it is very unlikely that the created document is already fully processed, so
-     *                      the extractions may not yet exist.
-     */
+
+/**
+ * Creates a new document from the given image.
+ *
+ * @param fileName      The file name of the document.
+ * @param image         An image representing the document.
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image __attribute__((deprecated("use createdDocumentWithFilename:fromData: methods instead")));
-    
-    /**
-     * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
-     * processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
-     * knows the doctype.
-     */
+
+/**
+ * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
+ * processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
+ * knows the doctype.
+ */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
                                docType:(NSString *)docType __attribute__((deprecated("use createdDocumentWithFilename:fromData: methods instead")));
-    
-    /**
-     * Creates a new document with the given `doctype` from the given data.
-     * Data can be in the format of a PDF, UTF-8 text or image representation.
-     * By providing the doctype, Gini's document processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @param fileName      The file name of the document.
-     * @param data          Data representing the document.
-     * @param docType       The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                      Please notice that it is very unlikely that the created document is already fully processed, so
-     *                      the extractions may not yet exist.
-     */
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @param fileName      The file name of the document.
+ * @param data          Data representing the document.
+ * @param docType       The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType;
-    
-    /**
-     * Creates a new document with the given `doctype` from the given data.
-     * Data can be in the format of a PDF, UTF-8 text or image representation.
-     * By providing the doctype, Gini's document processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @param fileName                  The file name of the document.
-     * @param data                      Data representing the document.
-     * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     *
-     * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                                  Please notice that it is very unlikely that the created document is already fully processed, so
-     *                                  the extractions may not yet exist.
-     */
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @param fileName                  The file name of the document.
+ * @param data                      Data representing the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ *
+ * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                                  Please notice that it is very unlikely that the created document is already fully processed, so
+ *                                  the extractions may not yet exist.
+ */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType
                      cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    
-    /**
-     * Creates a new document with the given `doctype` from the given data.
-     * Data can be in the format of a PDF, UTF-8 text or image representation.
-     * By providing the doctype, Gini's document processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @param fileName                  The file name of the document.
-     * @param data                      Data representing the document.
-     * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     * @param isPartialDocument         The document is part of a multi document
-     *
-     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                      Please notice that it is very unlikely that the created document is already fully processed, so
-     *                      the extractions may not yet exist.
-     */
+
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @param fileName                  The file name of the document.
+ * @param data                      Data representing the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param isPartialDocument         The document is part of a multi document
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType
                      isPartialDocument:(BOOL)isPartialDocument;
-    
-    /**
-     * Creates a new document with the given `doctype` from the given data.
-     * Data can be in the format of a PDF, UTF-8 text or image representation.
-     * By providing the doctype, Gini's document processing is optimized in many ways.
-     *
-     * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
-     * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     *
-     * @param fileName                  The file name of the document.
-     * @param data                      Data representing the document.
-     * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
-     * @param isPartialDocument         The document is part of a multi document
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     *
-     * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
-     *                      Please notice that it is very unlikely that the created document is already fully processed, so
-     *                      the extractions may not yet exist.
-     */
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @param fileName                  The file name of the document.
+ * @param data                      Data representing the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param isPartialDocument         The document is part of a multi document
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType
                      isPartialDocument:(BOOL)isPartialDocument
                      cancellationToken:(BFCancellationToken *)cancellationToken;
+/**
+ * Creates a new multi whatever document with the given subdocuments urls.
+ *
+ * @param subDocumentsURLs          Array containing the URL for each sub document.
+ * @param fileName                  The file name of the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created multi whatever document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
 
-- (BFTask *)createMultipageDocumentWithSubDocumentURLs:(NSArray<NSURL*>*)subDocumentURLs
-                                             fileName:(NSString *)fileName
-                                              docType:(NSString *)docType
-                                    cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Saves updates on the extractions.
-     *
-     * Updating extractions is called "Submitting feedback" in the Gini API documentation.
-     *
-     * @param document      The document.
-     */
+- (BFTask *)createMultipageDocumentWithSubDocumentsURLs:(NSArray<NSURL*>*)subDocumentsURLs
+                                               fileName:(NSString *)fileName
+                                                docType:(NSString *)docType
+                                      cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Saves updates on the extractions.
+ *
+ * Updating extractions is called "Submitting feedback" in the Gini API documentation.
+ *
+ * @param document      The document.
+ */
 - (BFTask *)updateDocument:(GINIDocument *)document;
-    
-    /**
-     * Saves updates on the extractions.
-     *
-     * Updating extractions is called "Submitting feedback" in the Gini API documentation.
-     *
-     * @param document                  The document.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     */
+
+/**
+ * Saves updates on the extractions.
+ *
+ * Updating extractions is called "Submitting feedback" in the Gini API documentation.
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
 - (BFTask *)updateDocument:(GINIDocument *)document
          cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Deletes the given document.
-     *
-     * @param document      The document that will be deleted.
-     */
+
+/**
+ * Deletes the given document.
+ *
+ * @param document      The document that will be deleted.
+ */
 - (BFTask *)deleteDocument:(GINIDocument *)document;
-    
-    /**
-     * Deletes the given document.
-     *
-     * @param document                  The document that will be deleted.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     */
+
+/**
+ * Deletes the given document.
+ *
+ * @param document                  The document that will be deleted.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
 - (BFTask *)deleteDocument:(GINIDocument *)document
          cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Continually checks the document status until the document is fully processed.
-     *
-     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
-     * available.
-     *
-     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
-     * `pollingInterval` property of this class.
-     *
-     * @warning             This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
-     *                      document. Please notice that the task's result will not be the same document object as the given
-     *                      document instance and the given document instance will not be updated with the polled results!
-     *
-     * @param document      The document that will be polled.
-     */
+
+/**
+ * Continually checks the document status until the document is fully processed.
+ *
+ * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+ * available.
+ *
+ * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+ * `pollingInterval` property of this class.
+ *
+ * @warning             This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
+ *                      document. Please notice that the task's result will not be the same document object as the given
+ *                      document instance and the given document instance will not be updated with the polled results!
+ *
+ * @param document      The document that will be polled.
+ */
 - (BFTask *)pollDocument:(GINIDocument *)document;
-    
-    /**
-     * Continually checks the document status until the document is fully processed.
-     *
-     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
-     * available.
-     *
-     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
-     * `pollingInterval` property of this class.
-     *
-     * @warning                         This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
-     *                                  document. Please notice that the task's result will not be the same document object as the given
-     *                                  document instance and the given document instance will not be updated with the polled results!
-     *
-     * @param document                  The document that will be polled.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     */
+
+/**
+ * Continually checks the document status until the document is fully processed.
+ *
+ * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+ * available.
+ *
+ * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+ * `pollingInterval` property of this class.
+ *
+ * @warning                         This method returns a `BFTask*` resolving to a `GINIDocument` instance representing the
+ *                                  document. Please notice that the task's result will not be the same document object as the given
+ *                                  document instance and the given document instance will not be updated with the polled results!
+ *
+ * @param document                  The document that will be polled.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
 - (BFTask *)pollDocument:(GINIDocument *)document
        cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Continually checks the document status until the document is fully processed.
-     *
-     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
-     * available.
-     *
-     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
-     * `pollingInterval` property of this class.
-     *
-     * @param documentId     The unique identifier of the document which will be polled.
-     */
+
+/**
+ * Continually checks the document status until the document is fully processed.
+ *
+ * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+ * available.
+ *
+ * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+ * `pollingInterval` property of this class.
+ *
+ * @param documentId     The unique identifier of the document which will be polled.
+ */
 - (BFTask *)pollDocumentWithId:(NSString *)documentId;
-    
-    /**
-     * Continually checks the document status until the document is fully processed.
-     *
-     * If the document is in the error state, this method also does not continue polling, but the extractions won't be
-     * available.
-     *
-     * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
-     * `pollingInterval` property of this class.
-     *
-     * @param documentId                The unique identifier of the document which will be polled.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     */
+
+/**
+ * Continually checks the document status until the document is fully processed.
+ *
+ * If the document is in the error state, this method also does not continue polling, but the extractions won't be
+ * available.
+ *
+ * To avoid flooding the network, there is a pause of at least the number of seconds that is set in the
+ * `pollingInterval` property of this class.
+ *
+ * @param documentId                The unique identifier of the document which will be polled.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
 - (BFTask *)pollDocumentWithId:(NSString *)documentId
              cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Gets the preview image for the given page of the given document.
-     *
-     * @param page          The page number of the document (starting from 1, not 0!).
-     * @param document      The document.
-     * @param size          The size in which the document will be rendered. Please notice that this is the maximum size,
-     *                      meaning that the images dimensions will not exceeding this limit but the rendered image can
-     *                      actually have a little smaller dimensions.
-     */
+
+/**
+ * Gets the preview image for the given page of the given document.
+ *
+ * @param page          The page number of the document (starting from 1, not 0!).
+ * @param document      The document.
+ * @param size          The size in which the document will be rendered. Please notice that this is the maximum size,
+ *                      meaning that the images dimensions will not exceeding this limit but the rendered image can
+ *                      actually have a little smaller dimensions.
+ */
 - (BFTask *)getPreviewForPage:(NSUInteger)page
                    ofDocument:(GINIDocument *)document
                      withSize:(GiniApiPreviewSize)size;
-    
-    /**
-     * Gets the preview image for the given page of the given document.
-     *
-     * @param page                      The page number of the document (starting from 1, not 0!).
-     * @param document                  The document.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     * @param size                      The size in which the document will be rendered. Please notice that this is the maximum size,
-     *                                  meaning that the images dimensions will not exceeding this limit but the rendered image can
-     *                                  actually have a little smaller dimensions.
-     */
+
+/**
+ * Gets the preview image for the given page of the given document.
+ *
+ * @param page                      The page number of the document (starting from 1, not 0!).
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ * @param size                      The size in which the document will be rendered. Please notice that this is the maximum size,
+ *                                  meaning that the images dimensions will not exceeding this limit but the rendered image can
+ *                                  actually have a little smaller dimensions.
+ */
 - (BFTask *)getPreviewForPage:(NSUInteger)page
                    ofDocument:(GINIDocument *)document
                      withSize:(GiniApiPreviewSize)size
             cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Gets the extractions for the given document.
-     *
-     * @param document      The document.
-     */
+
+/**
+ * Gets the extractions for the given document.
+ *
+ * @param document      The document.
+ */
 - (BFTask *)getExtractionsForDocument:(GINIDocument *)document;
-    
-    /**
-     * Gets the extractions for the given document.
-     *
-     * @param document                  The document.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     */
+
+/**
+ * Gets the extractions for the given document.
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
 - (BFTask *)getExtractionsForDocument:(GINIDocument *)document
                     cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Gets the extractions for the specific document, including the incubation extractions (see
-     * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
-     *
-     * @param document       The document.
-     */
+
+/**
+ * Gets the extractions for the specific document, including the incubation extractions (see
+ * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
+ *
+ * @param document       The document.
+ */
 - (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document;
-    
-    /**
-     * Gets the extractions for the specific document, including the incubation extractions (see
-     * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
-     *
-     * @param document                  The document.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     */
+
+/**
+ * Gets the extractions for the specific document, including the incubation extractions (see
+ * http://developer.gini.net/gini-api/html/incubator.html for details on incubating extractions).
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
 - (BFTask *)getIncubatorExtractionsForDocument:(GINIDocument *)document
                              cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Saves the new values for the given extraction of the given document.
-     *
-     * Please note that updating an extraction is called "Submitting feedback" in the Gini API documentation.
-     *
-     * @param extraction    The extraction.
-     * @param document      The document.
-     */
+
+/**
+ * Saves the new values for the given extraction of the given document.
+ *
+ * Please note that updating an extraction is called "Submitting feedback" in the Gini API documentation.
+ *
+ * @param extraction    The extraction.
+ * @param document      The document.
+ */
 - (BFTask *)updateExtraction:(GINIExtraction *)extraction forDocument:(GINIDocument *)document;
-    
-    /**
-     * Gets the layout for the given document.
-     *
-     * @param document      The document.
-     */
+
+/**
+ * Gets the layout for the given document.
+ *
+ * @param document      The document.
+ */
 - (BFTask *)getLayoutForDocument:(GINIDocument *)document;
-    
-    /**
-     * Gets the layout for the given document.
-     *
-     * @param document                  The document.
-     * @param cancellationToken         Cancellation token used to cancel the current task.
-     */
+
+/**
+ * Gets the layout for the given document.
+ *
+ * @param document                  The document.
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ */
 - (BFTask *)getLayoutForDocument:(GINIDocument *)document
                cancellationToken:(BFCancellationToken *)cancellationToken;
-    
-    /**
-     * Report an error for a specific document. If the processing result for a document was not satisfactory (e.g.
-     * extractions where empty or incorrect), you can create an error report for a document. This allows Gini to analyze and
-     * correct the problem that was found. The returned errorId can be used to refer to the reported error towards the Gini
-     * support.
-     *
-     * @warning The owner of this document must agree that Gini can use this document for debugging and error analysis.
-     *
-     * @param document          The document for which the error is reported.
-     * @param summary           A summary for the error (optional).
-     * @param description       A detailed description for the error (optional).
-     */
+
+/**
+ * Report an error for a specific document. If the processing result for a document was not satisfactory (e.g.
+ * extractions where empty or incorrect), you can create an error report for a document. This allows Gini to analyze and
+ * correct the problem that was found. The returned errorId can be used to refer to the reported error towards the Gini
+ * support.
+ *
+ * @warning The owner of this document must agree that Gini can use this document for debugging and error analysis.
+ *
+ * @param document          The document for which the error is reported.
+ * @param summary           A summary for the error (optional).
+ * @param description       A detailed description for the error (optional).
+ */
 - (BFTask *)errorReportForDocument:(GINIDocument *)document
                            summary:(NSString *)summary
                        description:(NSString *)description;
-    @end
+@end

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -75,7 +75,7 @@
  *                      the extractions may not yet exist.
  */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
-                             fromImage:(UIImage *)image __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: methods instead")));
+                             fromImage:(UIImage *)image __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
 
 /**
  * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
@@ -89,7 +89,7 @@
  */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
-                               docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: methods instead")));
+                               docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
 
 /**
  * Creates a new document with the given `doctype` from the given data.
@@ -109,15 +109,14 @@
  */
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
-                               docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: methods instead")));
+                               docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
 
 /**
- * Creates a new document with the given `doctype` from the given data.
+ * Creates a new partial document with the given `doctype` from the given data.
  * Data can be in the format of a PDF, UTF-8 text or image representation.
  * By providing the doctype, Gini's document processing is optimized in many ways.
  *
- * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
- * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * See the [Gini API documentation](Add documentation link).
  *
  * @param fileName                  The file name of the document.
  * @param data                      Data representing the document.
@@ -136,10 +135,11 @@
 /**
  * Creates a new composite document
  *
+ * See the [Gini API documentation](Add documentation link).
+ *
  * @param partialDocumentsInfo  Array containing the partial documents info (document url and additional parameters).
  * @param fileName              The filename of the document.
- * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
- *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
+ * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API.
  *                              for a list of possibles doctypes.
  * @param cancellationToken     Cancellation token used to cancel the current task.
  *
@@ -168,7 +168,7 @@
  *
  * @param document      The document that will be deleted.
  */
-- (BFTask *)deleteDocument:(GINIDocument *)document;
+- (BFTask *)deleteDocument:(GINIDocument *)document __attribute__((deprecated("use deleteCompositeDocumentWithId: method instead")));
 
 /**
  * Deletes the given document.
@@ -177,18 +177,18 @@
  * @param cancellationToken         Cancellation token used to cancel the current task.
  */
 - (BFTask *)deleteDocument:(GINIDocument *)document
-         cancellationToken:(BFCancellationToken *)cancellationToken;
+         cancellationToken:(BFCancellationToken *)cancellationToken __attribute__((deprecated("use deleteCompositeDocumentWithId: method instead")));
 
 /**
- * Deletes document with the given ID.
+ * Deletes composite document with the given ID.
  *
  * @param documentId               The document's id.
  * @param cancellationToken        Cancellation token used to cancel the current task.
  *
  * @returns                        A `BFTask*` with `nil` as result when the document has been deleted.
  */
-- (BFTask *)deleteDocumentWithId:(NSString *)documentId
-               cancellationToken:(BFCancellationToken *)cancellationToken;
+- (BFTask *)deleteCompositeDocumentWithId:(NSString *)documentId
+                        cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
  * Deletes partial document with the given ID.

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -113,11 +113,11 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return GINIhandleHTTPerrors(createTask);
 }
 
-- (BFTask *)createCompositeDocumentWithPartialDocumentsURLs:(NSArray<NSString *> *)partialDocumentsURLs
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<NSDictionary<NSString *,id> *> *)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *)cancellationToken {
-    BFTask* createTask = [[_apiManager createCompositeDocumentWithPartialDocumentsURLs:partialDocumentsURLs
+    BFTask* createTask = [[_apiManager createCompositeDocumentWithPartialDocumentsInfo:partialDocumentsInfo
                                                                               fileName:fileName
                                                                                docType:docType
                                                                      cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -146,7 +146,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 - (BFTask *)updateDocument:(GINIDocument *)document cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
     
-    BFTask *updateTask = [[document getExtractionsWithCancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
+    BFTask *updateTask = [[self getExtractionsForDocument:document cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         NSDictionary *extractions = task.result;
         NSMutableDictionary *updateExtractions = [NSMutableDictionary new];
         
@@ -335,7 +335,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                                                            label:extraction.name
                                                            value:extraction.value
                                                      boundingBox:extraction.box] continueWithSuccessBlock:^id(BFTask *task) {
-        [document.extractions continueWithSuccessBlock:^id(BFTask *extractionsTask) {
+        [[self getExtractionsForDocument:document] continueWithSuccessBlock:^id(BFTask *extractionsTask) {
             NSMutableDictionary *extractions = extractionsTask.result;
             extractions[extraction.name] = [GINIExtraction extractionWithName:extraction.name
                                                                         value:extraction.value

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -94,6 +94,24 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([data isKindOfClass:[NSData class]]);
     
+    BFTask *createTask = [[_apiManager uploadDocumentWithData:data
+                                                  contentType:@"image/jpeg"
+                                                     fileName:fileName
+                                                      docType:docType
+                                            cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
+        return [GINIDocument documentFromAPIResponse:task.result];
+    }];
+    return GINIhandleHTTPerrors(createTask);
+
+}
+
+- (BFTask *)createPartialDocumentWithFilename:(NSString *)fileName
+                                     fromData:(NSData *)data
+                                      docType:(NSString *)docType
+                            cancellationToken:(BFCancellationToken *)cancellationToken {
+    NSParameterAssert([fileName isKindOfClass:[NSString class]]);
+    NSParameterAssert([data isKindOfClass:[NSData class]]);
+    
     NSString* contentType = [data mimeType]; // i.e: image/jpeg
     
     NSString* lastContentTypeComponent = [[contentType componentsSeparatedByString:@"/"] lastObject];

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -75,13 +75,16 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return GINIhandleHTTPerrors(documentTask);
 }
 
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image {
     return [self createDocumentWithFilename:fileName
                                   fromImage:image
                                     docType:nil];
 }
 
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                               docType:(NSString *)docType {
     return [self createDocumentWithFilename:fileName
                                    fromData:UIImageJPEGRepresentation(image, 0.2)
                                     docType:@"image/jpeg"
@@ -89,14 +92,19 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                           cancellationToken:nil];
 }
 
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType {
     return [self createDocumentWithFilename:fileName
                                    fromData:data
                                     docType:docType
                           cancellationToken:nil];
 }
 
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                     cancellationToken:(BFCancellationToken *)cancellationToken {
     return [self createDocumentWithFilename:fileName
                                    fromData:data
                                     docType:docType
@@ -104,7 +112,10 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                           cancellationToken:cancellationToken];
 }
 
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType isPartialDocument:(BOOL)isPartialDocument {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                     isPartialDocument:(BOOL)isPartialDocument {
     return [self createDocumentWithFilename:fileName
                                    fromData:data
                                     docType:docType
@@ -112,17 +123,21 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                           cancellationToken:nil];
 }
 
-- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType isPartialDocument:(BOOL)isPartialDocument cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                     isPartialDocument:(BOOL)isPartialDocument
+                     cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([data isKindOfClass:[NSData class]]);
     
     NSString* contentType = [data mimeType]; // i.e: image/jpeg
     
     if (isPartialDocument) {
-        NSString* lastDocTypeComponent = [[contentType componentsSeparatedByString:@"/"] lastObject];
+        NSString* lastContentTypeComponent = [[contentType componentsSeparatedByString:@"/"] lastObject];
         NSString* concreteType = @"";  // i.e: jpeg
-        if (lastDocTypeComponent != nil && [lastDocTypeComponent length] > 0) {
-            concreteType = lastDocTypeComponent;
+        if (lastContentTypeComponent != nil && [lastContentTypeComponent length] > 0) {
+            concreteType = lastContentTypeComponent;
         }
         contentType = [NSString stringWithFormat:@"application/vnd.gini.v2.partial+%@", concreteType];
     }
@@ -137,14 +152,14 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return GINIhandleHTTPerrors(createTask);
 }
 
-- (BFTask *)createMultipageDocumentWithSubDocumentURLs:(NSArray<NSURL *> *)subDocumentURLs
+- (BFTask *)createMultipageDocumentWithSubDocumentsURLs:(NSArray<NSURL *> *)subDocumentsURLs
                                              fileName:(NSString *)fileName
                                               docType:(NSString *)docType
                                     cancellationToken:(BFCancellationToken *)cancellationToken {
-    BFTask *createTask = [[_apiManager uploadMultipageDocumentWithSubDocumentURLs:subDocumentURLs
-                                                                        fileName:fileName
-                                                                         docType:docType
-                                                               cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
+    BFTask *createTask = [[_apiManager uploadMultipageDocumentWithSubDocumentsURLs:subDocumentsURLs
+                                                                          fileName:fileName
+                                                                           docType:docType
+                                                                 cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
     }];
     return GINIhandleHTTPerrors(createTask);

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -80,15 +80,31 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image cancellationToken:(BFCancellationToken *)cancellationToken {
-    return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:nil cancellationToken:cancellationToken];
+    return [self createDocumentWithFilename:fileName fromImage:image isPartialDocument:false cancellationToken:cancellationToken];
+}
+    
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image isPartialDocument:(BOOL)isPartialDocument {
+    return [self createDocumentWithFilename:fileName fromImage:image isPartialDocument:isPartialDocument cancellationToken:nil];
+}
+    
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image isPartialDocument:(BOOL)isPartialDocument cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createDocumentWithFilename:fileName fromImage:image docType:nil isPartialDocument:isPartialDocument cancellationToken:cancellationToken];
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType {
     return [self createDocumentWithFilename:fileName fromImage:image docType:docType cancellationToken:nil];
 }
-
+    
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
-    return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:docType cancellationToken:cancellationToken];
+    return [self createDocumentWithFilename:fileName fromImage:image docType:docType isPartialDocument:false cancellationToken:cancellationToken];
+}
+    
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType isPartialDocument:(BOOL)isPartialDocument {
+    return [self createDocumentWithFilename:fileName fromImage:image docType:docType isPartialDocument:isPartialDocument cancellationToken:nil];
+}
+    
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromImage:(UIImage *)image docType:(NSString *)docType isPartialDocument:(BOOL)isPartialDocument cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createDocumentWithFilename:fileName fromData:UIImageJPEGRepresentation(image, 0.2) docType:@"image/jpeg" isPartialDocument:isPartialDocument cancellationToken:cancellationToken];
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType {
@@ -96,11 +112,26 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createDocumentWithFilename:fileName fromData:data docType:docType isPartialDocument:false cancellationToken:cancellationToken];
+}
+    
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType isPartialDocument:(BOOL)isPartialDocument {
+    return [self createDocumentWithFilename:fileName fromData:data docType:docType isPartialDocument:isPartialDocument cancellationToken:nil];
+}
+    
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName fromData:(NSData *)data docType:(NSString *)docType isPartialDocument:(BOOL)isPartialDocument cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([data isKindOfClass:[NSData class]]);
     
+    NSString* contentType;
+    if (isPartialDocument) {
+        contentType = @"application/vnd.gini.v2.partial+jpeg";
+    } else {
+        contentType = @"image/jpeg";
+    }
+    
     BFTask *createTask = [[_apiManager uploadDocumentWithData:data
-                                                  contentType:@"image/jpeg"
+                                                  contentType:contentType
                                                      fileName:fileName
                                                       docType:docType
                                             cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -192,11 +192,12 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
          cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
     
-    return [self deleteDocumentWithId:document.documentId cancellationToken:cancellationToken];
+    return [self deleteCompositeDocumentWithId:document.documentId
+                             cancellationToken:cancellationToken];
 }
 
-- (BFTask *)deleteDocumentWithId:(NSString *)documentId
-         cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)deleteCompositeDocumentWithId:(NSString *)documentId
+                        cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([documentId isKindOfClass:[NSString class]]);
     
     return GINIhandleHTTPerrors([_apiManager deleteDocument:documentId cancellationToken:cancellationToken]);
@@ -209,7 +210,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
         
         GINIDocument *document = (GINIDocument*) task.result;
         return [[self deleteDocumentsWithUrls:document.parents cancellationToken:cancellationToken] continueWithSuccessBlock: ^id(BFTask *task) {
-            return [self deleteDocumentWithId:document.documentId cancellationToken:cancellationToken];
+            return [self deleteCompositeDocumentWithId:document.documentId cancellationToken:cancellationToken];
         }];
     }];
 }
@@ -219,7 +220,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     
     for (NSString* url in urls) {
         NSString* documentId = [[url componentsSeparatedByString:@"/"] lastObject];
-        [deleteTasks addObject:[self deleteDocumentWithId:documentId cancellationToken:cancellationToken]];
+        [deleteTasks addObject:[self deleteCompositeDocumentWithId:documentId cancellationToken:cancellationToken]];
     }
     
     return [BFTask taskForCompletionOfAllTasks:deleteTasks];

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -137,6 +137,19 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return GINIhandleHTTPerrors(createTask);
 }
 
+- (BFTask *)createMultipageDocumentWithSubDocumentURLs:(NSArray<NSURL *> *)subDocumentURLs
+                                             fileName:(NSString *)fileName
+                                              docType:(NSString *)docType
+                                    cancellationToken:(BFCancellationToken *)cancellationToken {
+    BFTask *createTask = [[_apiManager uploadMultipageDocumentWithSubDocumentURLs:subDocumentURLs
+                                                                        fileName:fileName
+                                                                         docType:docType
+                                                               cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
+        return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
+    }];
+    return GINIhandleHTTPerrors(createTask);
+}
+
 - (BFTask *)updateDocument:(GINIDocument *)document {
     return [self updateDocument:document cancellationToken:nil];
 }

--- a/Gini-iOS-SDK/GINIPartialDocumentInfo.h
+++ b/Gini-iOS-SDK/GINIPartialDocumentInfo.h
@@ -1,0 +1,28 @@
+//
+//  GINIPartialDocumentInfo.h
+//  Gini-iOS-SDK
+//
+//  Created by Gini GmbH on 4/25/18.
+//
+
+@interface GINIPartialDocumentInfo: NSObject
+
+@property NSString *documentId;
+@property int rotationDelta;
+
+
+/**
+ * The designated initializer to create a `GINIPartialDocumentInfo`.
+ *
+ * @param documentId         Partial document id.
+ * @param rotationDelta      Rotation delta. Should be normalized to be in [0, 360).
+ */
+- (instancetype)initWithDocumentId:(NSString *)documentId rotationDelta:(int)rotationDelta;
+
+/**
+ * Method used to get the formatted json string for a partial document info.
+ *
+ * @returns     A formatted json string for this partial document info.
+ */
+- (NSString *)formattedJson;
+@end

--- a/Gini-iOS-SDK/GINIPartialDocumentInfo.m
+++ b/Gini-iOS-SDK/GINIPartialDocumentInfo.m
@@ -1,0 +1,29 @@
+//
+//  GINIPartialDocumentInfo.m
+//  Gini-iOS-SDK
+//
+//  Created by Gini GmbH on 4/25/18.
+//
+
+#import <Foundation/Foundation.h>
+#import "GINIPartialDocumentInfo.h"
+
+@implementation GINIPartialDocumentInfo
+
+- (instancetype)initWithDocumentId:(NSString *)documentId rotationDelta:(int)rotationDelta {
+    self = [super init];
+    if (self) {
+        _documentId = documentId;
+        _rotationDelta = rotationDelta;
+    }
+    
+    return self;
+}
+
+- (NSString *)formattedJson {
+    NSString * formattedString = [NSString stringWithFormat:@"{\"document\":\"%@\", \"rotationDelta\":%d}", _documentId, _rotationDelta];
+    
+    return formattedString;
+}
+
+@end

--- a/Gini-iOS-SDK/GINIURLSession.m
+++ b/Gini-iOS-SDK/GINIURLSession.m
@@ -19,7 +19,10 @@
 BOOL GINIIsJSONContent(NSString *contentType) {
     static NSSet *knownContentTypes;
     if (!knownContentTypes) {
-        knownContentTypes = [NSSet setWithObjects:@"application/json", @"application/vnd.gini.v1+json", @"application/vnd.gini.incubator+json", nil];
+        knownContentTypes = [NSSet setWithObjects:@"application/json",
+                             @"application/vnd.gini.v1+json",
+                             @"application/vnd.gini.v2+json",
+                             @"application/vnd.gini.incubator+json", nil];
     }
     NSArray *contentTypeComponents = [contentType componentsSeparatedByString:@";"];
     return ([knownContentTypes containsObject:contentTypeComponents.firstObject]);
@@ -31,7 +34,10 @@ BOOL GINIIsJSONContent(NSString *contentType) {
 BOOL GINIIsXMLContent(NSString *contentType) {
     static NSSet *knownContentTypes;
     if (!knownContentTypes) {
-        knownContentTypes = [NSSet setWithObjects:@"application/xml", @"application/vnd.gini.v1+xml", @"application/vnd.gini.incubator+xml", nil];
+        knownContentTypes = [NSSet setWithObjects:@"application/xml",
+                             @"application/vnd.gini.v1+xml",
+                             @"application/vnd.gini.v2+xml",
+                             @"application/vnd.gini.incubator+xml", nil];
     }
     NSArray *contentTypeComponents = [contentType componentsSeparatedByString:@";"];
     return ([knownContentTypes containsObject:contentTypeComponents.firstObject]);

--- a/Gini-iOS-SDK/GINIURLSession.m
+++ b/Gini-iOS-SDK/GINIURLSession.m
@@ -8,6 +8,7 @@
 #import "GINIURLSession.h"
 #import "GINIURLResponse.h"
 #import "GINIHTTPError.h"
+#import "GINIConstants.h"
 
 
 #define GINI_DEFAULT_ENCODING NSUTF8StringEncoding
@@ -19,10 +20,10 @@
 BOOL GINIIsJSONContent(NSString *contentType) {
     static NSSet *knownContentTypes;
     if (!knownContentTypes) {
-        knownContentTypes = [NSSet setWithObjects:@"application/json",
-                             @"application/vnd.gini.v1+json",
-                             @"application/vnd.gini.v2+json",
-                             @"application/vnd.gini.incubator+json", nil];
+        knownContentTypes = [NSSet setWithObjects:GINIContentApplicationJson,
+                             GINIContentJsonV1,
+                             GINIContentJsonV2,
+                             GINIIncubatorJson, nil];
     }
     NSArray *contentTypeComponents = [contentType componentsSeparatedByString:@";"];
     return ([knownContentTypes containsObject:contentTypeComponents.firstObject]);
@@ -34,10 +35,10 @@ BOOL GINIIsJSONContent(NSString *contentType) {
 BOOL GINIIsXMLContent(NSString *contentType) {
     static NSSet *knownContentTypes;
     if (!knownContentTypes) {
-        knownContentTypes = [NSSet setWithObjects:@"application/xml",
-                             @"application/vnd.gini.v1+xml",
-                             @"application/vnd.gini.v2+xml",
-                             @"application/vnd.gini.incubator+xml", nil];
+        knownContentTypes = [NSSet setWithObjects:GINIContentApplicationXml,
+                             GINIContentXmlV1,
+                             GINIContentXmlV2,
+                             GINIIncubatorXml, nil];
     }
     NSArray *contentTypeComponents = [contentType componentsSeparatedByString:@";"];
     return ([knownContentTypes containsObject:contentTypeComponents.firstObject]);

--- a/Gini-iOS-SDK/GINIURLSessionDelegate.h
+++ b/Gini-iOS-SDK/GINIURLSessionDelegate.h
@@ -2,7 +2,7 @@
 //  GINIURLSessionDelegate.h
 //  Gini-iOS-SDK
 //
-//  Created by Enrique del Pozo Gómez on 12/11/17.
+//  Created by Gini GmbH on 12/11/17.
 //  Copyright © 2017 Gini GmbH. All rights reserved.
 //
 #import <Foundation/Foundation.h>

--- a/Gini-iOS-SDK/GINIURLSessionDelegate.m
+++ b/Gini-iOS-SDK/GINIURLSessionDelegate.m
@@ -2,7 +2,7 @@
 //  GINIURLSessionDelegate.m
 //  Gini-iOS-SDK
 //
-//  Created by Enrique del Pozo Gómez on 12/11/17.
+//  Created by Gini GmbH on 12/11/17.
 //  Copyright © 2017 Gini GmbH. All rights reserved.
 //
 

--- a/Gini-iOS-SDK/GINIUserCenterManager.m
+++ b/Gini-iOS-SDK/GINIUserCenterManager.m
@@ -13,7 +13,7 @@
 #import "GINIUser.h"
 #import "GINIError.h"
 #import "GINIHTTPError.h"
-
+#import "GINIConstants.h"
 
 NSString *const GINIUserCreationNotification = @"UserCreationNotification";
 NSString *const GINIUserCreationErrorNotification = @"UserCreationNotification";
@@ -73,7 +73,7 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
 
     return [[self createMutableURLRequest:[NSString stringWithFormat:@"/api/users/%@", userID] httpMethod:@"GET"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *urlRequest = requestTask.result;
-        [urlRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+        [urlRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Accept"];
         return [[self->_urlSession BFDataTaskWithRequest:urlRequest] continueWithSuccessBlock:^id(BFTask *task) {
             GINIURLResponse *urlResponse = task.result;
             return [GINIUser userFromAPIResponse:urlResponse.data];
@@ -88,8 +88,8 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
     // This needs an active session with a bearer token.
     return [[self createMutableURLRequest:@"/api/users" httpMethod:@"POST"] continueWithSuccessBlock:^id(BFTask *requestTask) {
         NSMutableURLRequest *urlRequest = requestTask.result;
-        [urlRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-        [urlRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+        [urlRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Content-Type"];
+        [urlRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Accept"];
         NSDictionary *payload = @{
                 @"email" : email,
                 @"password" : password
@@ -122,7 +122,7 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
     NSURL *URL = [NSURL URLWithString:@"/oauth/token?grant_type=password" relativeToURL:_baseURL];
     NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:URL];
     [urlRequest setHTTPMethod:@"POST"];
-    [urlRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [urlRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Accept"];
     [urlRequest setValue:[self createLoginHeader] forHTTPHeaderField:@"Authorization"];
     // Login data (x-www-urlencoded).
     NSData *loginData = [[NSString stringWithFormat:@"username=%@&password=%@", stringByEscapingString(userName), stringByEscapingString(password)] dataUsingEncoding:NSUTF8StringEncoding];
@@ -160,7 +160,7 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
     NSURL *URL = [NSURL URLWithString:endpointPath relativeToURL:_baseURL];
     NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:URL];
     [urlRequest setHTTPMethod:@"GET"];
-    [urlRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [urlRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Accept"];
 
     return [_urlSession BFDataTaskWithRequest:urlRequest];
 }
@@ -192,8 +192,8 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
         // This needs an active session with a bearer token.
         return [[self createMutableURLRequest:url httpMethod:@"PUT"] continueWithSuccessBlock:^id(BFTask *requestTask) {
             NSMutableURLRequest *urlRequest = requestTask.result;
-            [urlRequest setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-            [urlRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+            [urlRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Content-Type"];
+            [urlRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Accept"];
             NSDictionary *payload = @{
                                       @"oldEmail" : oldEmail,
                                       @"email" : newEmail
@@ -238,7 +238,7 @@ NSString *const GINILoginErrorNotification = @"LoginErrorNotification";
     NSURL *loginURL = [NSURL URLWithString:@"/oauth/token?grant_type=client_credentials" relativeToURL:_baseURL];
     NSMutableURLRequest *loginRequest = [NSMutableURLRequest requestWithURL:loginURL];
     [loginRequest setHTTPMethod:@"GET"];
-    [loginRequest setValue:@"application/json" forHTTPHeaderField:@"Accept"];
+    [loginRequest setValue:GINIContentApplicationJson forHTTPHeaderField:@"Accept"];
     [loginRequest setValue:[self createLoginHeader] forHTTPHeaderField:@"Authorization"];
     return [[_urlSession BFDataTaskWithRequest:loginRequest] continueWithSuccessBlock:^id(BFTask *task) {
         GINIURLResponse *response = task.result;

--- a/Gini-iOS-SDK/GiniDocumentLinks.h
+++ b/Gini-iOS-SDK/GiniDocumentLinks.h
@@ -1,0 +1,18 @@
+//
+//  GINIDocumentLinks.h
+//  Gini-iOS-SDK
+//
+//  Created by Gini GmbH on 3/27/18.
+//
+
+@interface GINIDocumentLinks: NSObject
+    @property (readonly) NSString *document;
+    @property (readonly) NSString *extractions;
+    @property (readonly) NSString *layout;
+    @property (readonly) NSString *processed;
+
+- (instancetype) initWithDocumentURL:(NSString *)documentURL
+                      extractionsURL:(NSString *)extractionsURL
+                           layoutURL:(NSString *)layoutURL
+                        processedURL:(NSString *)processedURL;
+@end

--- a/Gini-iOS-SDK/GiniDocumentLinks.m
+++ b/Gini-iOS-SDK/GiniDocumentLinks.m
@@ -1,0 +1,29 @@
+//
+//  GINIDocumentLinks.m
+//  Gini-iOS-SDK
+//
+//  Created by Gini GmbH on 3/27/18.
+//
+
+#import <GiniDocumentLinks.h>
+
+@implementation GINIDocumentLinks {
+    
+}
+
+- (instancetype)initWithDocumentURL:(NSString *)documentURL
+                    extractionsURL:(NSString *)extractionsURL
+                         layoutURL:(NSString *)layoutURL
+                      processedURL:(NSString *)processedURL {
+    self = [super init];
+    if (self) {
+        _document = documentURL;
+        _extractions = extractionsURL;
+        _layout = layoutURL;
+        _processed = processedURL;
+    }
+    
+    return self;
+}
+
+@end

--- a/Gini-iOS-SDK/NSData+MimeTypes.h
+++ b/Gini-iOS-SDK/NSData+MimeTypes.h
@@ -2,7 +2,7 @@
 //  NSData+MimeTypes.h
 //  Gini-iOS-SDK
 //
-//  Created by Enrique del Pozo Gómez on 3/27/18.
+//  Created by Gini GmbH on 3/27/18.
 //
 
 #import <Foundation/Foundation.h>

--- a/Gini-iOS-SDK/NSData+MimeTypes.h
+++ b/Gini-iOS-SDK/NSData+MimeTypes.h
@@ -1,0 +1,12 @@
+//
+//  NSData+MimeTypes.h
+//  Gini-iOS-SDK
+//
+//  Created by Enrique del Pozo Gómez on 3/27/18.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSData (MimeTypes)
+- (NSString*) mimeType;
+@end

--- a/Gini-iOS-SDK/NSData+MimeTypes.m
+++ b/Gini-iOS-SDK/NSData+MimeTypes.m
@@ -2,7 +2,7 @@
 //  NSData+MimeTypes.m
 //  Gini-iOS-SDK
 //
-//  Created by Enrique del Pozo Gómez on 3/27/18.
+//  Created by Gini GmbH on 3/27/18.
 //
 
 #import "NSData+MimeTypes.h"

--- a/Gini-iOS-SDK/NSData+MimeTypes.m
+++ b/Gini-iOS-SDK/NSData+MimeTypes.m
@@ -1,0 +1,43 @@
+//
+//  NSData+MimeTypes.m
+//  Gini-iOS-SDK
+//
+//  Created by Enrique del Pozo Gómez on 3/27/18.
+//
+
+#import "NSData+MimeTypes.h"
+
+@implementation NSData (MimeTypes)
+
+- (NSString*)mimeType {
+    uint8_t c;
+    [self getBytes:&c length:1];
+    
+    switch (c) {
+        case 0xFF:
+            return @"image/jpeg";
+            break;
+        case 0x89:
+            return @"image/png";
+            break;
+        case 0x47:
+            return @"image/gif";
+            break;
+        case 0x49:
+        case 0x4D:
+            return @"image/tiff";
+            break;
+        case 0x25:
+            return @"application/pdf";
+            break;
+        case 0xD0:
+            return @"application/vnd";
+            break;
+        case 0x46:
+            return @"text/plain";
+            break;
+        default:
+            return @"application/octet-stream";
+    }
+}
+@end

--- a/Gini-iOS-SDKTests/GINIAPIManagerSpec.m
+++ b/Gini-iOS-SDKTests/GINIAPIManagerSpec.m
@@ -46,7 +46,7 @@ describe(@"The GINIAPIManager", ^{
         // Check for the correct URL.
         NSURLRequest *request = urlSessionMock.lastRequest;
         // Check for the correct content type
-        [[[request valueForHTTPHeaderField:@"Accept"] should] equal:@"application/vnd.gini.v1+json"];
+        [[[request valueForHTTPHeaderField:@"Accept"] should] equal:@"application/vnd.gini.v2+json"];
     };
 
     /**
@@ -57,7 +57,7 @@ describe(@"The GINIAPIManager", ^{
         // Check for the correct URL.
         NSURLRequest *request = urlSessionMock.lastRequest;
         // Check for the correct content type
-        [[[request valueForHTTPHeaderField:@"Accept"] should] equal:@"application/vnd.gini.v1+xml"];
+        [[[request valueForHTTPHeaderField:@"Accept"] should] equal:@"application/vnd.gini.v2+xml"];
     };
 
     /**
@@ -242,7 +242,7 @@ describe(@"The GINIAPIManager", ^{
                                                                           HTTPVersion:@"1.1"
                                                                          headerFields:@{
                                                                              @"Location": createdDocumentsURL,
-                                                                             @"Content-Type": @"application/vnd.gini.v1+json"
+                                                                             @"Content-Type": @"application/vnd.gini.v2+json"
                                                                          }];
             GINIURLResponse *response = [GINIURLResponse urlResponseWithResponse:nsURLResponse data:[NSData new]];
             [urlSessionMock setResponse:[BFTask taskWithResult:response] forURL:uploadURL];
@@ -258,7 +258,7 @@ describe(@"The GINIAPIManager", ^{
                                                                           HTTPVersion:@"1.1"
                                                                          headerFields:@{
                                                                                  @"Location": createdDocumentsURL,
-                                                                                 @"Content-Type": @"application/vnd.gini.v1+json"
+                                                                                 @"Content-Type": @"application/vnd.gini.v2+json"
                                                                          }];
             GINIURLResponse *response = [GINIURLResponse urlResponseWithResponse:nsURLResponse data:[NSData new]];
             [urlSessionMock setResponse:[BFTask taskWithResult:response] forURL:uploadURL];

--- a/Gini-iOS-SDKTests/GINIAPIManagerSpec.m
+++ b/Gini-iOS-SDKTests/GINIAPIManagerSpec.m
@@ -12,6 +12,7 @@
 #import "BFTask.h"
 #import "GINIURLResponse.h"
 #import "NSString+GINIAdditions.h"
+#import "GINIPartialDocumentInfo.h"
 
 
 SPEC_BEGIN(GINIAPIManagerSpec)
@@ -544,6 +545,38 @@ describe(@"The GINIAPIManager", ^{
             [[json[@"feedback"] should] equal:feedback];
         });
     });;
+    
+    context(@"The createCompositeDocumentWithPartialDocumentsInfo method", ^{
+        it(@"should return a BFTask*", ^{
+            [[[apiManager createCompositeDocumentWithPartialDocumentsInfo:[NSArray new]
+                                                                fileName:@"FileName"
+                                                                 docType:nil
+                                                       cancellationToken:nil] should] beKindOfClass:[BFTask class]];
+        });
+        
+        it(@"should do a POST request", ^{
+            [apiManager createCompositeDocumentWithPartialDocumentsInfo:[NSArray new]
+                                                               fileName:@"FileName"
+                                                                docType:nil
+                                                      cancellationToken:nil];
+            NSURLRequest *request = urlSessionMock.requests[0];
+            [[request.HTTPMethod should] equal:@"POST"];
+        });
+        
+        it(@"should create the correct body", ^{
+            NSArray<GINIPartialDocumentInfo *> *partialDocumentsInfo = [[NSArray alloc] initWithObjects:
+                                                                        [[GINIPartialDocumentInfo alloc] initWithDocumentId:@"1234" rotationDelta:0],
+                                                                        [[GINIPartialDocumentInfo alloc] initWithDocumentId:@"5678" rotationDelta:90],
+                                                                        nil];
+            [apiManager createCompositeDocumentWithPartialDocumentsInfo:partialDocumentsInfo
+                                                               fileName:@"FileName"
+                                                                docType:nil
+                                                      cancellationToken:nil];
+            NSURLRequest *request = urlSessionMock.requests[0];
+            NSString* originalJsonString = [[NSString alloc] initWithData:[request HTTPBody] encoding:NSUTF8StringEncoding];
+            [[originalJsonString should] equal:@"{\"partialDocuments\": [{\"document\":\"1234\", \"rotationDelta\":0},{\"document\":\"5678\", \"rotationDelta\":90}]}"];
+        });
+    });
 });
 
 

--- a/Gini-iOS-SDKTests/GINIDocumentSpec.m
+++ b/Gini-iOS-SDKTests/GINIDocumentSpec.m
@@ -28,58 +28,58 @@ describe(@"The GINIDocument", ^{
     });
 
     it(@"should have a factory which creates a document from the API response", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[instance should] beKindOfClass:[GINIDocument class]];
     });
 
     it(@"should set the correct page number", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue(instance.pageCount) should] equal:theValue(1)];
 
         documentJsonData[@"pageCount"] = @23;
-        GINIDocument *secondInstance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *secondInstance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue(secondInstance.pageCount) should] equal:theValue(23)];
     });
 
     it(@"should set the correct filename", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[instance.filename should] equal:@"scanned.jpg"];
 
         documentJsonData[@"name"] = @"foobar.jpg";
-        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[instance.filename should] equal:@"foobar.jpg"];
     });
 
     it(@"should set the correct source classification", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue(instance.sourceClassification) should] equal:theValue(GiniDocumentSourceClassificationScanned)];
 
         documentJsonData[@"sourceClassification"] = @"NATIVE";
-        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue(instance.sourceClassification) should] equal:theValue(GiniDocumentSourceClassificationNative)];
     });
 
     it(@"should set the correct creation date", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[instance.creationDate should] beKindOfClass:[NSDate class]];
         [[theValue([instance.creationDate isEqualToDate:[NSDate dateWithTimeIntervalSince1970:1360623867]]) should] beYes];
     });
 
     it(@"should set the correct document state", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStateComplete)];
 
         documentJsonData[@"progress"] = @"PENDING";
-        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStatePending)];
 
         documentJsonData[@"progress"] = @"ERROR";
-        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStateError)];
     });
     
     it(@"should have the correct links", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[instance.links.document should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000"];
         [[instance.links.extractions should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/extractions"];
         [[instance.links.layout should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/layout"];
@@ -87,12 +87,12 @@ describe(@"The GINIDocument", ^{
     });
 
     it(@"should have a nice description", ^{
-        GINIDocument *document = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *document = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[[document description] should] equal:@"<GINIDocument id=626626a0-749f-11e2-bfd6-000000000000>"];
     });
     
     it(@"should set the correct document state", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue([instance.parents count]) should] equal:theValue(2)];
     });
     
@@ -114,13 +114,18 @@ describe(@"The composite GINIDocument", ^{
     });
     
     it(@"should have a factory which creates a document from the API response", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[instance should] beKindOfClass:[GINIDocument class]];
     });
     
     it(@"should set the correct document state", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
         [[theValue([instance.partialDocuments count]) should] equal:theValue(2)];
+    });
+    
+    it(@"should set the correct source classification", ^{
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData withDocumentManager:documentTaskManager];
+        [[theValue(instance.sourceClassification) should] equal:theValue(GiniDocumentSourceClassificationComposite)];
     });
     
 });

--- a/Gini-iOS-SDKTests/GINIDocumentSpec.m
+++ b/Gini-iOS-SDKTests/GINIDocumentSpec.m
@@ -15,72 +15,71 @@ SPEC_BEGIN(GINIDocumentSpec)
 describe(@"The GINIDocument", ^{
     __block GINIDocumentTaskManager *documentTaskManager;
     __block GINIAPIManagerMock *apiManager;
-    __block NSMutableDictionary *jsonData;
+    __block NSMutableDictionary *documentJsonData;
 
     beforeEach(^{
         apiManager = [GINIAPIManagerMock new];
         documentTaskManager = [GINIDocumentTaskManager documentTaskManagerWithAPIManager:apiManager];
 
-        NSURL *dataPath = [[NSBundle bundleForClass:[self class]] URLForResource:@"document" withExtension:@"json"];
-        jsonData = [NSMutableDictionary dictionaryWithDictionary:[NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:dataPath]
+        NSURL *documentDataPath = [[NSBundle bundleForClass:[self class]] URLForResource:@"document" withExtension:@"json"];
+        documentJsonData = [NSMutableDictionary dictionaryWithDictionary:[NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:documentDataPath]
                                                                                                  options:NSJSONReadingAllowFragments
                                                                                                    error:nil]];
-
     });
 
     it(@"should have a factory which creates a document from the API response", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[instance should] beKindOfClass:[GINIDocument class]];
     });
 
     it(@"should set the correct page number", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[theValue(instance.pageCount) should] equal:theValue(1)];
 
-        jsonData[@"pageCount"] = @23;
-        GINIDocument *secondInstance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        documentJsonData[@"pageCount"] = @23;
+        GINIDocument *secondInstance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[theValue(secondInstance.pageCount) should] equal:theValue(23)];
     });
 
     it(@"should set the correct filename", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[instance.filename should] equal:@"scanned.jpg"];
 
-        jsonData[@"name"] = @"foobar.jpg";
-        instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        documentJsonData[@"name"] = @"foobar.jpg";
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[instance.filename should] equal:@"foobar.jpg"];
     });
 
     it(@"should set the correct source classification", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[theValue(instance.sourceClassification) should] equal:theValue(GiniDocumentSourceClassificationScanned)];
 
-        jsonData[@"sourceClassification"] = @"NATIVE";
-        instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        documentJsonData[@"sourceClassification"] = @"NATIVE";
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[theValue(instance.sourceClassification) should] equal:theValue(GiniDocumentSourceClassificationNative)];
     });
 
     it(@"should set the correct creation date", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[instance.creationDate should] beKindOfClass:[NSDate class]];
         [[theValue([instance.creationDate isEqualToDate:[NSDate dateWithTimeIntervalSince1970:1360623867]]) should] beYes];
     });
 
     it(@"should set the correct document state", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStateComplete)];
 
-        jsonData[@"progress"] = @"PENDING";
-        instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        documentJsonData[@"progress"] = @"PENDING";
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStatePending)];
 
-        jsonData[@"progress"] = @"ERROR";
-        instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        documentJsonData[@"progress"] = @"ERROR";
+        instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStateError)];
     });
     
     it(@"should has the correct links", ^{
-        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[instance.links.document should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000"];
         [[instance.links.extractions should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/extractions"];
         [[instance.links.layout should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/layout"];
@@ -88,21 +87,42 @@ describe(@"The GINIDocument", ^{
     });
 
     it(@"should have a nice description", ^{
-        GINIDocument *document = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        GINIDocument *document = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[[document description] should] equal:@"<GINIDocument id=626626a0-749f-11e2-bfd6-000000000000>"];
     });
-
-    it(@"should have a property to get the extractions", ^{
-        GINIDocument *document = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
-        [[document.extractions should] beKindOfClass:[BFTask class]];
+    
+    it(@"should set the correct document state", ^{
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        [[theValue([instance.parents count]) should] equal:theValue(2)];
     });
+    
+});
 
-    it(@"should have a property to get the candidates", ^{
-        GINIDocument *document = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
-        [[document.candidates should] beKindOfClass:[BFTask class]];
+describe(@"The composite GINIDocument", ^{
+    __block GINIDocumentTaskManager *documentTaskManager;
+    __block GINIAPIManagerMock *apiManager;
+    __block NSMutableDictionary *documentJsonData;
+    
+    beforeEach(^{
+        apiManager = [GINIAPIManagerMock new];
+        documentTaskManager = [GINIDocumentTaskManager documentTaskManagerWithAPIManager:apiManager];
+        
+        NSURL *documentDataPath = [[NSBundle bundleForClass:[self class]] URLForResource:@"compositedocument" withExtension:@"json"];
+        documentJsonData = [NSMutableDictionary dictionaryWithDictionary:[NSJSONSerialization JSONObjectWithData:[NSData dataWithContentsOfURL:documentDataPath]
+                                                                                                         options:NSJSONReadingAllowFragments
+                                                                                                           error:nil]];
     });
-
-    // TODO more tests for the document tasks.
+    
+    it(@"should have a factory which creates a document from the API response", ^{
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        [[instance should] beKindOfClass:[GINIDocument class]];
+    });
+    
+    it(@"should set the correct document state", ^{
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
+        [[theValue([instance.partialdocuments count]) should] equal:theValue(2)];
+    });
+    
 });
 
 SPEC_END

--- a/Gini-iOS-SDKTests/GINIDocumentSpec.m
+++ b/Gini-iOS-SDKTests/GINIDocumentSpec.m
@@ -78,7 +78,7 @@ describe(@"The GINIDocument", ^{
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStateError)];
     });
     
-    it(@"should has the correct links", ^{
+    it(@"should have the correct links", ^{
         GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
         [[instance.links.document should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000"];
         [[instance.links.extractions should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/extractions"];

--- a/Gini-iOS-SDKTests/GINIDocumentSpec.m
+++ b/Gini-iOS-SDKTests/GINIDocumentSpec.m
@@ -120,7 +120,7 @@ describe(@"The composite GINIDocument", ^{
     
     it(@"should set the correct document state", ^{
         GINIDocument *instance = [GINIDocument documentFromAPIResponse:documentJsonData];
-        [[theValue([instance.partialdocuments count]) should] equal:theValue(2)];
+        [[theValue([instance.partialDocuments count]) should] equal:theValue(2)];
     });
     
 });

--- a/Gini-iOS-SDKTests/GINIDocumentSpec.m
+++ b/Gini-iOS-SDKTests/GINIDocumentSpec.m
@@ -78,6 +78,14 @@ describe(@"The GINIDocument", ^{
         instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
         [[theValue(instance.state) should] equal:theValue(GiniDocumentStateError)];
     });
+    
+    it(@"should has the correct links", ^{
+        GINIDocument *instance = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];
+        [[instance.links.document should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000"];
+        [[instance.links.extractions should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/extractions"];
+        [[instance.links.layout should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/layout"];
+        [[instance.links.processed should] equal:@"https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/processed"];
+    });
 
     it(@"should have a nice description", ^{
         GINIDocument *document = [GINIDocument documentFromAPIResponse:jsonData withDocumentManager:documentTaskManager];

--- a/Gini-iOS-SDKTests/GINIDocumentTaskManagerSpec.m
+++ b/Gini-iOS-SDKTests/GINIDocumentTaskManagerSpec.m
@@ -54,19 +54,37 @@ describe(@"The GINIDocumentTaskManager", ^{
         });
 
         it(@"should return a BFTask*", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStateComplete pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative links:nil];
+            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234"
+                                                                state:GiniDocumentStateComplete
+                                                            pageCount:0
+                                                 sourceClassification:GiniDocumentSourceClassificationNative
+                                                                links:nil
+                                                              parents:nil
+                                                     partialDocuments:nil];
             BFTask *task = [documentTaskManager pollDocument:document];
             [[task should] beKindOfClass:[BFTask class]];
         });
 
         it(@"should immediately return the document if it is in the processing state COMPLETED", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStateComplete pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative links:nil];
+            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234"
+                                                                state:GiniDocumentStateComplete
+                                                            pageCount:0
+                                                 sourceClassification:GiniDocumentSourceClassificationNative
+                                                                links:nil
+                                                              parents:nil
+                                                     partialDocuments:nil];
             [documentTaskManager pollDocument:document];
             [[theValue(apiManager.getDocumentCalled) should] equal:theValue(0)];
         });
 
         it(@"should poll if it is in the processing state pending", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStatePending pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative links:nil];
+            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234"
+                                                                state:GiniDocumentStatePending
+                                                            pageCount:0
+                                                 sourceClassification:GiniDocumentSourceClassificationNative
+                                                                links:nil
+                                                              parents:nil
+                                                     partialDocuments:nil];
             BFTask *task = [documentTaskManager pollDocument:document];
             [[theValue(apiManager.getDocumentCalled) should] equal:theValue(1)];
             GINIDocument *updatedDocument = task.result;

--- a/Gini-iOS-SDKTests/GINIDocumentTaskManagerSpec.m
+++ b/Gini-iOS-SDKTests/GINIDocumentTaskManagerSpec.m
@@ -54,19 +54,19 @@ describe(@"The GINIDocumentTaskManager", ^{
         });
 
         it(@"should return a BFTask*", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStateComplete pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative documentManager:nil];
+            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStateComplete pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative links:nil];
             BFTask *task = [documentTaskManager pollDocument:document];
             [[task should] beKindOfClass:[BFTask class]];
         });
 
         it(@"should immediately return the document if it is in the processing state COMPLETED", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStateComplete pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative documentManager:nil];
+            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStateComplete pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative links:nil];
             [documentTaskManager pollDocument:document];
             [[theValue(apiManager.getDocumentCalled) should] equal:theValue(0)];
         });
 
         it(@"should poll if it is in the processing state pending", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStatePending pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative documentManager:nil];
+            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStatePending pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative links:nil];
             BFTask *task = [documentTaskManager pollDocument:document];
             [[theValue(apiManager.getDocumentCalled) should] equal:theValue(1)];
             GINIDocument *updatedDocument = task.result;
@@ -74,15 +74,6 @@ describe(@"The GINIDocumentTaskManager", ^{
             [[theValue(updatedDocument.state) should] equal:theValue(GiniDocumentStateComplete)];
 
         });
-    });
-
-    context(@"The updateDocument method", ^{
-        it(@"should return a BFTask*", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234" state:GiniDocumentStateComplete pageCount:0 sourceClassification:GiniDocumentSourceClassificationNative documentManager:documentTaskManager];
-            BFTask *task = [documentTaskManager updateDocument:document];
-            [[task should] beKindOfClass:[BFTask class]];
-        });
-        // TODO: more tests
     });
 
     context(@"The createDocumentWithFilename:fromImage: method", ^{
@@ -141,24 +132,6 @@ describe(@"The GINIDocumentTaskManager", ^{
             NSData *data = [NSData dataWithContentsOfURL:dataPath];
             
             [[[documentTaskManager createDocumentWithFilename:@"foobar.jpg" fromData:data docType:@"Invoice"] should] beKindOfClass:[BFTask class]];
-        });
-    });
-
-    context(@"The errorReportForDocument:summary:description: method", ^{
-        it(@"should raise an exception when having the wrong arguments", ^{
-            [[theBlock(^{
-                [documentTaskManager errorReportForDocument:nil summary:nil description:nil];
-            }) should] raise];
-        });
-
-        it(@"should return a BFTask*", ^{
-            GINIDocument *document = [[GINIDocument alloc] initWithId:@"1234"
-                                                                state:GiniDocumentStatePending
-                                                            pageCount:1
-                                                 sourceClassification:GiniDocumentSourceClassificationNative
-                                                      documentManager:documentTaskManager];
-            BFTask *errorReportTask = [documentTaskManager errorReportForDocument:document summary:@"foo error" description:@"Short description."];
-            [[errorReportTask should] beKindOfClass:[BFTask class]];
         });
     });
 });

--- a/Gini-iOS-SDKTests/GINIPartialDocumentInfoSpec.m
+++ b/Gini-iOS-SDKTests/GINIPartialDocumentInfoSpec.m
@@ -1,0 +1,23 @@
+//
+//  GINIPartialDocumentInfoSpec.m
+//  Gini-iOS-SDKTests
+//
+//  Created by Gini GmbH on 4/25/18.
+//  Copyright © 2018 Gini GmbH. All rights reserved.
+//
+
+#import <Kiwi/Kiwi.h>
+#import "GINIPartialDocumentInfo.h"
+
+SPEC_BEGIN(GINIPartialDocumentInfoSpec)
+
+describe(@"the GINIPartialDocumentInfo", ^{
+    it(@"should create the correct formatted json string", ^{
+        GINIPartialDocumentInfo *partialDocumentInfo = [[GINIPartialDocumentInfo alloc] initWithDocumentId:@"123456"
+                                                                                             rotationDelta:90];
+        NSString *formattedString = @"{\"document\":\"123456\", \"rotationDelta\":90}";
+
+        [[[partialDocumentInfo formattedJson] should] equal:formattedString];
+    });
+});
+SPEC_END

--- a/Gini-iOS-SDKTests/Resources/compositedocument.json
+++ b/Gini-iOS-SDKTests/Resources/compositedocument.json
@@ -21,8 +21,8 @@
         "document": "https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000",
         "processed": "https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/processed"
     },
-    "parents": [
-        "https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000001",
-        "https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000002"
+    "partialdocuments": [
+        "https://api.gini.net/documents/626626a0-749f-11e2-bfd2-000000000000",
+        "https://api.gini.net/documents/626626a0-749f-11e2-bfd3-000000000000"
     ]
 }

--- a/Gini-iOS-SDKTests/Resources/compositedocument.json
+++ b/Gini-iOS-SDKTests/Resources/compositedocument.json
@@ -4,7 +4,7 @@
     "name": "scanned.jpg",
     "progress": "COMPLETED",
     "origin": "UPLOAD",
-    "sourceClassification": "SCANNED",
+    "sourceClassification": "COMPOSITE",
     "pageCount": 1,
     "pages" : [
         {
@@ -21,7 +21,7 @@
         "document": "https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000",
         "processed": "https://api.gini.net/documents/626626a0-749f-11e2-bfd6-000000000000/processed"
     },
-    "partialdocuments": [
+    "partialDocuments": [
         "https://api.gini.net/documents/626626a0-749f-11e2-bfd2-000000000000",
         "https://api.gini.net/documents/626626a0-749f-11e2-bfd3-000000000000"
     ]


### PR DESCRIPTION
For multi-page analysis, several methods have been added into the `GINIDocumentTaskManager` class, along with some document related methods that were in the `GINIDocument` class.
FYI, methods which have the `cancellationToken` parameter don't come from last public release but from a previous PR.

### How to test
Not possible yet since it is only available for local development.

### Merging
Automatic.

Issue #69 