### PR TITLE
Fix concurrent builds issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,9 @@ pipeline {
   stages {
     stage('Prerequisites') {
       steps {
-        sh '/usr/local/bin/pod install --repo-update'
+        lock('refs/remotes/origin/master') {
+           sh '/usr/local/bin/pod install --repo-update'
+	}
       }
     }
     stage('Build') {


### PR DESCRIPTION
### Description
When running 'pod repo update' in different builds at the same time, one of the build failed since they were trying to access the same resource.

### How to test
Run two branches in parallel.

### Merging
Automatic

### Issues
