### PR TITLE
Metadata headers

### DIFF
--- a/Gini-iOS-SDK.xcodeproj/project.pbxproj
+++ b/Gini-iOS-SDK.xcodeproj/project.pbxproj
@@ -341,8 +341,6 @@
 				0A845B811DAE9AC300AD2D64 /* Sources */,
 				0A845B821DAE9AC300AD2D64 /* Frameworks */,
 				0A845B831DAE9AC300AD2D64 /* Resources */,
-				380C433E8AFF5863AA063AAB /* [CP] Embed Pods Frameworks */,
-				B0AF0A6760A3D117DE95534D /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -361,8 +359,6 @@
 				23D53C001934BC85001A957E /* Sources */,
 				23D53C011934BC85001A957E /* Frameworks */,
 				23D53C021934BC85001A957E /* Resources */,
-				866B5D558C429F37DE51B64D /* [CP] Embed Pods Frameworks */,
-				D7CBFB66403BEC7BDF9B8E49 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -466,36 +462,6 @@
 			shellPath = /bin/sh;
 			shellScript = "echo $OTHER_CFLAGS";
 		};
-		380C433E8AFF5863AA063AAB /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GiniSDK Example/Pods-GiniSDK Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		866B5D558C429F37DE51B64D /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Gini-iOS-SDKTests/Pods-Gini-iOS-SDKTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8EA93F8DEA9DF47460BAC2DB /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -530,36 +496,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B0AF0A6760A3D117DE95534D /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GiniSDK Example/Pods-GiniSDK Example-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D7CBFB66403BEC7BDF9B8E49 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Gini-iOS-SDKTests/Pods-Gini-iOS-SDKTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -221,7 +221,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @param docType           (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
  *                          [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
  *                          for a list of possibles doctypes.
- * @param metadata          (Optional) The document metadata
+ * @param metadata          (Optional) The document metadata containing any custom information regarding the upload (used later for reporting)
  * @param cancellationToken Cancellation token used to cancel the current task.
  *
  * @returns                 A`BFTask*` that will resolve to a NSString containing the created document's ID.
@@ -264,7 +264,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
  *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
  *                              for a list of possibles doctypes.
- * @param metadata              (Optional) The document metadata.
+ * @param metadata              (Optional) The document metadata containing any custom information regarding the upload (used later for reporting).
  * @param cancellationToken     Cancellation token used to cancel the current task.
  *
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -6,6 +6,7 @@
 @class BFTask;
 @class BFCancellationToken;
 @class GINIPartialDocumentInfo;
+@class GINIDocumentMetadata;
 @protocol GINIAPIManagerRequestFactory;
 @protocol GINIURLSession;
 
@@ -209,6 +210,28 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
                            docType:(NSString *)docType
                  cancellationToken:(BFCancellationToken *) cancellationToken;
 
+/**
+ * Creates a new document from the given NSData*.
+ *
+ * @param documentData      Data containing the document. This should be in a format that is supported by the Gini API, see
+ *                          [the Gini API documentation](http://developer.gini.net/gini-api/html/documents.html?highlight=put#supported-file-formats)
+ *                          for details.
+ * @param contentType       The content type of the document (as a MIME string).
+ * @param fileName          The filename of the document.
+ * @param docType           (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
+ *                          [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
+ *                          for a list of possibles doctypes.
+ * @param cancellationToken Cancellation token used to cancel the current task.
+ *
+ * @returns                 A`BFTask*` that will resolve to a NSString containing the created document's ID.
+ */
+- (BFTask *)uploadDocumentWithData:(NSData *)documentData
+                       contentType:(NSString *)contentType
+                          fileName:(NSString *)fileName
+                           docType:(NSString *)docType
+                          metadata:(GINIDocumentMetadata *)metadata
+                 cancellationToken:(BFCancellationToken *) cancellationToken;
+
 
 /**
  * Creates a new composite document
@@ -228,6 +251,27 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
 - (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *>*)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
+                                          cancellationToken:(BFCancellationToken *) cancellationToken;
+
+/**
+ * Creates a new composite document
+ *
+ * See the [Gini API Documentation](Add documentation link).
+ *
+ * @param partialDocumentsInfo  Array containing the partial documents info. More info can be found [here](Add here documentation link)
+ * @param fileName              The filename of the document.
+ * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
+ *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
+ *                              for a list of possibles doctypes.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
+ */
+
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *>*)partialDocumentsInfo
+                                                   fileName:(NSString *)fileName
+                                                    docType:(NSString *)docType
+                                                   metadata:(GINIDocumentMetadata *)metadata
                                           cancellationToken:(BFCancellationToken *) cancellationToken;
 
 

--- a/Gini-iOS-SDK/GINIAPIManager.h
+++ b/Gini-iOS-SDK/GINIAPIManager.h
@@ -221,6 +221,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @param docType           (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
  *                          [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
  *                          for a list of possibles doctypes.
+ * @param metadata          (Optional) The document metadata
  * @param cancellationToken Cancellation token used to cancel the current task.
  *
  * @returns                 A`BFTask*` that will resolve to a NSString containing the created document's ID.
@@ -263,6 +264,7 @@ typedef NS_ENUM(NSUInteger, GiniAPIResponseType){
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API. See the
  *                              [Gini API documentation](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype)
  *                              for a list of possibles doctypes.
+ * @param metadata              (Optional) The document metadata.
  * @param cancellationToken     Cancellation token used to cancel the current task.
  *
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -210,9 +210,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
         NSMutableURLRequest *request = requestTask.result;
         [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
         
-        if (metadata != nil) {
-            [self addMetadata:metadata toRequest:request];
-        }
+        [self addMetadata:metadata toRequest:request];
         
         return [[self->_urlSession BFUploadTaskWithRequest:requestTask.result fromData:documentData] continueWithSuccessBlock:^id(BFTask *uploadTask) {
             // The HTTP response has a Location header with the URL of the document.
@@ -252,10 +250,8 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
         NSMutableURLRequest *request = requestTask.result;
         [request setValue:GINICompositeJsonV2 forHTTPHeaderField:@"Content-Type"];
         
-        if (metadata != nil) {
-            [self addMetadata:metadata toRequest:request];
-        }
-        
+        [self addMetadata:metadata toRequest:request];
+
         return [[self->_urlSession BFUploadTaskWithRequest:requestTask.result fromData:jsonDataFormatted] continueWithSuccessBlock:^id(BFTask *uploadTask) {
             // The HTTP response has a Location header with the URL of the document.
             GINIURLResponse *response = uploadTask.result;

--- a/Gini-iOS-SDK/GINIAPIManager.m
+++ b/Gini-iOS-SDK/GINIAPIManager.m
@@ -211,9 +211,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
         [request setValue:contentType forHTTPHeaderField:@"Content-Type"];
         
         if (metadata != nil) {
-            for (NSString* key in metadata.headers) {
-                [request setValue:metadata.headers[key] forHTTPHeaderField:key];
-            }
+            [self addMetadata:metadata toRequest:request];
         }
         
         return [[self->_urlSession BFUploadTaskWithRequest:requestTask.result fromData:documentData] continueWithSuccessBlock:^id(BFTask *uploadTask) {
@@ -255,9 +253,7 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
         [request setValue:GINICompositeJsonV2 forHTTPHeaderField:@"Content-Type"];
         
         if (metadata != nil) {
-            for (NSString* key in metadata.headers) {
-                [request setValue:metadata.headers[key] forHTTPHeaderField:key];
-            }
+            [self addMetadata:metadata toRequest:request];
         }
         
         return [[self->_urlSession BFUploadTaskWithRequest:requestTask.result fromData:jsonDataFormatted] continueWithSuccessBlock:^id(BFTask *uploadTask) {
@@ -466,6 +462,12 @@ NSString *GINIPreviewSizeString(GiniApiPreviewSize previewSize) {
     NSString* jsonDataFormattedString = [NSString stringWithFormat: @"{\"partialDocuments\": [%@]}", [partialInfoFormattedJsonStrings componentsJoinedByString:@","]];
     NSData *jsonDataFormatted = [jsonDataFormattedString dataUsingEncoding:NSUTF8StringEncoding];
     return jsonDataFormatted;
+}
+
+- (void)addMetadata:(GINIDocumentMetadata *)metadata toRequest:(NSMutableURLRequest *)request {
+    for (NSString* key in metadata.headers) {
+        [request setValue:metadata.headers[key] forHTTPHeaderField:key];
+    }
 }
 
 @end

--- a/Gini-iOS-SDK/GINIConstants.h
+++ b/Gini-iOS-SDK/GINIConstants.h
@@ -23,4 +23,5 @@ extern NSString* const ExtractionIbanKey;
 extern NSString* const ExtractionBicKey;
 extern NSString* const ExtractionPaymentPurposeKey;
 
-extern NSString* const BranchIdHeaderKey;
+extern NSString* const MetadataHeaderKeyPrefix;
+extern NSString* const MetadataBranchIdHeaderKey;

--- a/Gini-iOS-SDK/GINIConstants.h
+++ b/Gini-iOS-SDK/GINIConstants.h
@@ -22,3 +22,5 @@ extern NSString* const ExtractionPaymentRecipientKey;
 extern NSString* const ExtractionIbanKey;
 extern NSString* const ExtractionBicKey;
 extern NSString* const ExtractionPaymentPurposeKey;
+
+extern NSString* const BranchIdHeaderKey;

--- a/Gini-iOS-SDK/GINIConstants.m
+++ b/Gini-iOS-SDK/GINIConstants.m
@@ -30,3 +30,7 @@ NSString* const ExtractionPaymentRecipientKey = @"paymentRecipient";
 NSString* const ExtractionIbanKey = @"iban";
 NSString* const ExtractionBicKey = @"bic";
 NSString* const ExtractionPaymentPurposeKey = @"paymentPurpose";
+
+// Metadata headers
+
+NSString* const BranchIdHeaderKey = @"X-Document-Metadata-BranchId";

--- a/Gini-iOS-SDK/GINIConstants.m
+++ b/Gini-iOS-SDK/GINIConstants.m
@@ -33,4 +33,6 @@ NSString* const ExtractionPaymentPurposeKey = @"paymentPurpose";
 
 // Metadata headers
 
-NSString* const BranchIdHeaderKey = @"X-Document-Metadata-BranchId";
+NSString* const MetadataHeaderKeyPrefix = @"X-Document-Metadata-";
+NSString* const MetadataBranchIdHeaderKey = @"BranchId";
+

--- a/Gini-iOS-SDK/GINIDocumentMetadata.h
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.h
@@ -8,6 +8,20 @@
 @interface GINIDocumentMetadata: NSObject
     @property (readonly) NSDictionary<NSString *, NSString *> *headers;
 
+/**
+ * The document metadata initializer.
+ *
+ * @param branchId              The branch id
+ */
+- (instancetype) initWithBranchId:(NSString *)branchId;
+
+/**
+ * The document metadata initializer.
+ *
+ * @param branchId              The branch id
+ * @param additionalHeaders     Additional headers for the metadata. i.e: ["customerId":"123456"]
+ */
 - (instancetype) initWithBranchId:(NSString *)branchId
                 additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders;
+
 @end

--- a/Gini-iOS-SDK/GINIDocumentMetadata.h
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.h
@@ -13,21 +13,21 @@
     @property (readonly) NSDictionary<NSString *, NSString *> *headers;
 
 /**
- * The document metadata initializer.
+ * The document metadata initializer with only the branch ID (BLZ)
  *
  * @param branchId              The branch id - Bankleitzahl (BLZ)
  */
 - (instancetype) initWithBranchId:(NSString *)branchId;
 
 /**
- * The document metadata initializer.
+ * The document metadata initializer with only custom headers
  *
  * @param headers               Additional headers for the metadata. i.e: ["customerId":"123456"]
  */
 - (instancetype)initWithHeaders:(NSDictionary<NSString *,NSString *> *)headers;
 
 /**
- * The document metadata initializer.
+ * The document metadata initializer with the branch ID (BLZ) and additional custom headers
  *
  * @param branchId              The branch id - Bankleitzahl (BLZ)
  * @param additionalHeaders     Additional headers for the metadata. i.e: ["customerId":"123456"]

--- a/Gini-iOS-SDK/GINIDocumentMetadata.h
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.h
@@ -6,16 +6,17 @@
 //
 
 /**
- * The GINIDocumentMetadata contains any custom information regarding the upload (used later for reporting).
+ * The GINIDocumentMetadata contains any custom information regarding the upload (used later for reporting),
+ * creating HTTP headers with an specific format.
  *
  */
 @interface GINIDocumentMetadata: NSObject
     @property (readonly) NSDictionary<NSString *, NSString *> *headers;
 
 /**
- * The document metadata initializer with only the branch ID (BLZ)
+ * The document metadata initializer with only the branch ID (i.e: the BLZ of a Bank in Germany)
  *
- * @param branchId              The branch id - Bankleitzahl (BLZ)
+ * @param branchId              The branch id (i.e: the BLZ of a Bank in Germany)
  */
 - (instancetype) initWithBranchId:(NSString *)branchId;
 
@@ -27,9 +28,9 @@
 - (instancetype)initWithHeaders:(NSDictionary<NSString *,NSString *> *)headers;
 
 /**
- * The document metadata initializer with the branch ID (BLZ) and additional custom headers
+ * The document metadata initializer with the branch ID and additional custom headers
  *
- * @param branchId              The branch id - Bankleitzahl (BLZ)
+ * @param branchId              The branch id (i.e: the BLZ of a Bank in Germany)
  * @param additionalHeaders     Additional headers for the metadata. i.e: ["customerId":"123456"]
  */
 - (instancetype) initWithBranchId:(NSString *)branchId

--- a/Gini-iOS-SDK/GINIDocumentMetadata.h
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.h
@@ -5,20 +5,31 @@
 //  Created by Enrique del Pozo Gómez on 10/24/18.
 //
 
+/**
+ * The GINIDocumentMetadata contains any custom information regarding the upload (used later for reporting).
+ *
+ */
 @interface GINIDocumentMetadata: NSObject
     @property (readonly) NSDictionary<NSString *, NSString *> *headers;
 
 /**
  * The document metadata initializer.
  *
- * @param branchId              The branch id
+ * @param branchId              The branch id - Bankleitzahl (BLZ)
  */
 - (instancetype) initWithBranchId:(NSString *)branchId;
 
 /**
  * The document metadata initializer.
  *
- * @param branchId              The branch id
+ * @param headers               Additional headers for the metadata. i.e: ["customerId":"123456"]
+ */
+- (instancetype)initWithHeaders:(NSDictionary<NSString *,NSString *> *)headers;
+
+/**
+ * The document metadata initializer.
+ *
+ * @param branchId              The branch id - Bankleitzahl (BLZ)
  * @param additionalHeaders     Additional headers for the metadata. i.e: ["customerId":"123456"]
  */
 - (instancetype) initWithBranchId:(NSString *)branchId

--- a/Gini-iOS-SDK/GINIDocumentMetadata.h
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.h
@@ -1,0 +1,13 @@
+//
+//  GINIDocumentMetadata.h
+//  Gini-iOS-SDK
+//
+//  Created by Enrique del Pozo Gómez on 10/24/18.
+//
+
+@interface GINIDocumentMetadata: NSObject
+    @property (readonly) NSDictionary<NSString *, NSString *> *headers;
+
+- (instancetype) initWithBranchId:(NSString *)branchId
+                additionalHeaders:(NSDictionary<NSString *, NSString *> *)additionalHeaders;
+@end

--- a/Gini-iOS-SDK/GINIDocumentMetadata.m
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.m
@@ -14,21 +14,26 @@
     return [self initWithBranchId:branchId additionalHeaders:nil];
 }
 
+- (instancetype)initWithHeaders:(NSDictionary<NSString *,NSString *> *)headers {
+    return [self initWithBranchId:nil additionalHeaders:headers];
+}
+
 - (instancetype)initWithBranchId:(NSString *)branchId
                additionalHeaders:(NSDictionary<NSString *,NSString *> *)additionalHeaders {
     
-    _headers = [[NSMutableDictionary alloc] initWithCapacity:additionalHeaders.count + 1];
-    
-    NSString *branchIdKey = [self formattedKey:MetadataBranchIdHeaderKey];
-    [_headers setValue:branchId forKey:branchIdKey];
-    
-    if(additionalHeaders != nil) {
-        for (NSString* key in additionalHeaders) {
-            NSParameterAssert(![key containsString:MetadataHeaderKeyPrefix]);
-            
-            [_headers setValue:additionalHeaders[key] forKey:[self formattedKey:key]];
-        }
+    NSMutableDictionary* headers = [[NSMutableDictionary alloc] init];
+    if(branchId != nil) {
+        NSString *branchIdKey = [self formattedKey:MetadataBranchIdHeaderKey];
+        [headers setValue:branchId forKey:branchIdKey];
     }
+
+    for (NSString* key in additionalHeaders) {
+        NSParameterAssert(![key containsString:MetadataHeaderKeyPrefix]);
+            
+        [headers setValue:additionalHeaders[key] forKey:[self formattedKey:key]];
+    }
+    
+    _headers = headers;
     
     return self;
 }

--- a/Gini-iOS-SDK/GINIDocumentMetadata.m
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.m
@@ -1,0 +1,22 @@
+//
+//  GINIDocumentMetadata.m
+//  Gini-iOS-SDK
+//
+//  Created by Enrique del Pozo Gómez on 10/24/18.
+//
+
+#import <GINIDocumentMetadata.h>
+#import <GINIConstants.h>
+
+@implementation GINIDocumentMetadata
+
+- (instancetype)initWithBranchId:(NSString *)branchId
+               additionalHeaders:(NSDictionary<NSString *,NSString *> *)additionalHeaders {
+    _headers = [[NSMutableDictionary alloc] initWithDictionary:additionalHeaders];
+    [_headers setValue:branchId forKey:BranchIdHeaderKey];
+    
+    return self;
+}
+
+@end
+

--- a/Gini-iOS-SDK/GINIDocumentMetadata.m
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.m
@@ -12,10 +12,25 @@
 
 - (instancetype)initWithBranchId:(NSString *)branchId
                additionalHeaders:(NSDictionary<NSString *,NSString *> *)additionalHeaders {
-    _headers = [[NSMutableDictionary alloc] initWithDictionary:additionalHeaders];
-    [_headers setValue:branchId forKey:BranchIdHeaderKey];
+    
+    _headers = [[NSMutableDictionary alloc] initWithCapacity:additionalHeaders.count + 1];
+    
+    NSString *branchIdKey = [self formattedKey:MetadataBranchIdHeaderKey];
+    [_headers setValue:branchId forKey:branchIdKey];
+    
+    for (NSString* key in additionalHeaders) {
+        NSParameterAssert(![key containsString:MetadataHeaderKeyPrefix]);
+        
+        [_headers setValue:additionalHeaders[key] forKey:[self formattedKey:key]];
+    }
     
     return self;
+}
+
+- (NSString *)formattedKey:(NSString *) key {
+    return [[NSString alloc] initWithFormat:@"%@%@",
+            MetadataHeaderKeyPrefix,
+            key];
 }
 
 @end

--- a/Gini-iOS-SDK/GINIDocumentMetadata.m
+++ b/Gini-iOS-SDK/GINIDocumentMetadata.m
@@ -10,6 +10,10 @@
 
 @implementation GINIDocumentMetadata
 
+- (instancetype)initWithBranchId:(NSString *)branchId {
+    return [self initWithBranchId:branchId additionalHeaders:nil];
+}
+
 - (instancetype)initWithBranchId:(NSString *)branchId
                additionalHeaders:(NSDictionary<NSString *,NSString *> *)additionalHeaders {
     
@@ -18,10 +22,12 @@
     NSString *branchIdKey = [self formattedKey:MetadataBranchIdHeaderKey];
     [_headers setValue:branchId forKey:branchIdKey];
     
-    for (NSString* key in additionalHeaders) {
-        NSParameterAssert(![key containsString:MetadataHeaderKeyPrefix]);
-        
-        [_headers setValue:additionalHeaders[key] forKey:[self formattedKey:key]];
+    if(additionalHeaders != nil) {
+        for (NSString* key in additionalHeaders) {
+            NSParameterAssert(![key containsString:MetadataHeaderKeyPrefix]);
+            
+            [_headers setValue:additionalHeaders[key] forKey:[self formattedKey:key]];
+        }
     }
     
     return self;

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -84,6 +84,7 @@
  *
  * @param fileName      The file name of the document.
  * @param image         An image representing the document.
+ * @param metadata      (Optional) The document metadata.
  *
  * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
  *                      Please notice that it is very unlikely that the created document is already fully processed, so
@@ -153,6 +154,7 @@
  * @param fileName      The file name of the document.
  * @param data          Data representing the document.
  * @param docType       The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param metadata      (Optional) The document metadata.
  *
  * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
  *                      Please notice that it is very unlikely that the created document is already fully processed, so
@@ -194,6 +196,7 @@
  * @param fileName                  The file name of the document.
  * @param data                      Data representing the document.
  * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param metadata                  (Optional) The document metadata.
  * @param cancellationToken         Cancellation token used to cancel the current task.
  *
  * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
@@ -234,6 +237,7 @@
  * @param fileName              The filename of the document.
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API.
  *                              for a list of possibles doctypes.
+ * @param metadata              (Optional) The document metadata.
  * @param cancellationToken     Cancellation token used to cancel the current task.
  *
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -7,6 +7,7 @@
 #import <UIKit/UIKit.h>
 #import "GINIAPIManager.h"
 #import "GINIPartialDocumentInfo.h"
+#import "GINIDocumentMetadata.h"
 
 @class BFTask;
 @class GINIDocument;
@@ -79,6 +80,20 @@
                              fromImage:(UIImage *)image __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
 
 /**
+ * Creates a new document from the given image.
+ *
+ * @param fileName      The file name of the document.
+ * @param image         An image representing the document.
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                              metadata:(GINIDocumentMetadata *)metadata __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
+
+/**
  * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
  * processing is optimized in many ways.
  *
@@ -91,6 +106,21 @@
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
                                docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
+
+/**
+ * Creates a new document with the given `doctype` from the given image. By providing the doctype, Gini's document
+ * processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @warning Some incubating extractions are only available if you create the document with this method, so the Gini API
+ * knows the doctype.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                               docType:(NSString *)docType
+                              metadata:(GINIDocumentMetadata *)metadata  __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
 
 /**
  * Creates a new document with the given `doctype` from the given data.
@@ -111,6 +141,27 @@
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @param fileName      The file name of the document.
+ * @param data          Data representing the document.
+ * @param docType       The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                      Please notice that it is very unlikely that the created document is already fully processed, so
+ *                      the extractions may not yet exist.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                              metadata:(GINIDocumentMetadata *)metadata  __attribute__((deprecated("use createPartialDocumentWithFilename:fromData:docType:cancellationToken: method instead")));
 
 /**
  * Creates a new partial document with the given `doctype` from the given data.
@@ -134,6 +185,28 @@
                             cancellationToken:(BFCancellationToken *)cancellationToken;
 
 /**
+ * Creates a new partial document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](Add documentation link).
+ *
+ * @param fileName                  The file name of the document.
+ * @param data                      Data representing the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ *
+ * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                                  Please notice that it is very unlikely that the created document is already fully processed, so
+ *                                  the extractions may not yet exist.
+ */
+- (BFTask *)createPartialDocumentWithFilename:(NSString *)fileName
+                                     fromData:(NSData *)data
+                                      docType:(NSString *)docType
+                                     metadata:(GINIDocumentMetadata *)metadata
+                            cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
  * Creates a new composite document
  *
  * See the [Gini API documentation](Add documentation link).
@@ -150,6 +223,26 @@
 - (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *>*)partialDocumentsInfo
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
+                                          cancellationToken:(BFCancellationToken *) cancellationToken;
+
+/**
+ * Creates a new composite document
+ *
+ * See the [Gini API documentation](Add documentation link).
+ *
+ * @param partialDocumentsInfo  Array containing the partial documents info (document url and additional parameters).
+ * @param fileName              The filename of the document.
+ * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API.
+ *                              for a list of possibles doctypes.
+ * @param cancellationToken     Cancellation token used to cancel the current task.
+ *
+ * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.
+ */
+
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *>*)partialDocumentsInfo
+                                                   fileName:(NSString *)fileName
+                                                    docType:(NSString *)docType
+                                                   metadata:(GINIDocumentMetadata *)metadata
                                           cancellationToken:(BFCancellationToken *) cancellationToken;
 
 

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -84,7 +84,7 @@
  *
  * @param fileName      The file name of the document.
  * @param image         An image representing the document.
- * @param metadata      (Optional) The document metadata.
+ * @param metadata      (Optional) The document metadata containing any custom information regarding the upload (used later for reporting).
  *
  * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
  *                      Please notice that it is very unlikely that the created document is already fully processed, so
@@ -154,7 +154,7 @@
  * @param fileName      The file name of the document.
  * @param data          Data representing the document.
  * @param docType       The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- * @param metadata      (Optional) The document metadata.
+ * @param metadata      (Optional) The document metadata containing any custom information regarding the upload (used later for reporting).
  *
  * @returns             A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
  *                      Please notice that it is very unlikely that the created document is already fully processed, so
@@ -196,7 +196,7 @@
  * @param fileName                  The file name of the document.
  * @param data                      Data representing the document.
  * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
- * @param metadata                  (Optional) The document metadata.
+ * @param metadata                  (Optional) The document metadata containing any custom information regarding the upload (used later for reporting).
  * @param cancellationToken         Cancellation token used to cancel the current task.
  *
  * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
@@ -237,7 +237,7 @@
  * @param fileName              The filename of the document.
  * @param docType               (Optional) A doctype hint. This optimizes the processing at the Gini API.
  *                              for a list of possibles doctypes.
- * @param metadata              (Optional) The document metadata.
+ * @param metadata              (Optional) The document metadata containing any custom information regarding the upload (used later for reporting).
  * @param cancellationToken     Cancellation token used to cancel the current task.
  *
  * @returns                     A`BFTask*` that will resolve to a NSString containing the created document's ID.

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -171,7 +171,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                                                   contentType:contentType
                                                      fileName:fileName
                                                       docType:docType
-                                                     metadata: metadata
+                                                     metadata:metadata
                                             cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
     }];

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -67,16 +67,35 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                              fromImage:(UIImage *)image {
     return [self createDocumentWithFilename:fileName
                                   fromImage:image
-                                    docType:nil];
+                                   metadata:nil];
+}
+
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                              metadata:(GINIDocumentMetadata *)metadata {
+    return [self createDocumentWithFilename:fileName
+                                   fromImage:image
+                                    docType:@"image/jpeg"
+                                   metadata:metadata];
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                              fromImage:(UIImage *)image
                                docType:(NSString *)docType {
     return [self createDocumentWithFilename:fileName
+                                   fromImage:image
+                                    docType:docType
+                                   metadata:nil];
+}
+
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                             fromImage:(UIImage *)image
+                               docType:(NSString *)docType
+                              metadata:(GINIDocumentMetadata *)metadata {
+    return [self createDocumentWithFilename:fileName
                                    fromData:UIImageJPEGRepresentation(image, 0.2)
-                                    docType:@"image/jpeg"
-                          cancellationToken:nil];
+                                    docType:docType
+                                   metadata:metadata];
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
@@ -85,12 +104,25 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
     return [self createDocumentWithFilename:fileName
                                    fromData:data
                                     docType:docType
-                          cancellationToken:nil];
+                                   metadata:nil];
 }
 
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType
+                              metadata:(GINIDocumentMetadata *)metadata {
+    return [self createDocumentWithFilename:fileName
+                                   fromData:data
+                                    docType:docType
+                                   metadata:metadata
+                          cancellationToken:nil];
+}
+
+
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                              metadata:metadata
                      cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([data isKindOfClass:[NSData class]]);
@@ -99,6 +131,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                                                   contentType:[data mimeType]
                                                      fileName:fileName
                                                       docType:docType
+                                                     metadata: metadata
                                             cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
     }];
@@ -109,6 +142,18 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 - (BFTask *)createPartialDocumentWithFilename:(NSString *)fileName
                                      fromData:(NSData *)data
                                       docType:(NSString *)docType
+                            cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createPartialDocumentWithFilename:fileName
+                                          fromData:data
+                                           docType:docType
+                                          metadata:nil
+                                 cancellationToken:cancellationToken];
+}
+
+- (BFTask *)createPartialDocumentWithFilename:(NSString *)fileName
+                                     fromData:(NSData *)data
+                                      docType:(NSString *)docType
+                                     metadata:(GINIDocumentMetadata *)metadata
                             cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);
     NSParameterAssert([data isKindOfClass:[NSData class]]);
@@ -126,6 +171,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                                                   contentType:contentType
                                                      fileName:fileName
                                                       docType:docType
+                                                     metadata: metadata
                                             cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
     }];
@@ -136,9 +182,21 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                                                    fileName:(NSString *)fileName
                                                     docType:(NSString *)docType
                                           cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createCompositeDocumentWithPartialDocumentsInfo:partialDocumentsInfo
+                                                        fileName:fileName
+                                                         docType:docType
+                                                        metadata:nil
+                                               cancellationToken:cancellationToken];
+}
+
+- (BFTask *)createCompositeDocumentWithPartialDocumentsInfo:(NSArray<GINIPartialDocumentInfo *> *)partialDocumentsInfo
+                                                   fileName:(NSString *)fileName docType:(NSString *)docType
+                                                   metadata:(GINIDocumentMetadata *)metadata
+                                          cancellationToken:(BFCancellationToken *)cancellationToken {
     BFTask* createTask = [[_apiManager createCompositeDocumentWithPartialDocumentsInfo:partialDocumentsInfo
                                                                               fileName:fileName
                                                                                docType:docType
+                                                                              metadata:metadata
                                                                      cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
     }];

--- a/Gini-iOS-SDKTests/HelperClasses/GINIAPIManagerMock.m
+++ b/Gini-iOS-SDKTests/HelperClasses/GINIAPIManagerMock.m
@@ -46,6 +46,7 @@
                        contentType:(NSString *)contentType
                           fileName:(NSString *)fileName
                            docType:(NSString *)docType
+                          metadata:(GINIDocumentMetadata *)metadata
                  cancellationToken:(BFCancellationToken *)cancellationToken {
     NSParameterAssert([documentData isKindOfClass:[NSData class]]);
     NSParameterAssert([fileName isKindOfClass:[NSString class]]);

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - Bolts/AppLinks (1.9.0):
     - Bolts/Tasks
   - Bolts/Tasks (1.9.0)
-  - Gini-iOS-SDK (1.0.0-alpha.1):
-    - Gini-iOS-SDK/Core (= 1.0.0-alpha.1)
-  - Gini-iOS-SDK/Core (1.0.0-alpha.1):
+  - Gini-iOS-SDK (1.0.0):
+    - Gini-iOS-SDK/Core (= 1.0.0)
+  - Gini-iOS-SDK/Core (1.0.0):
     - Bolts (~> 1.9)
-  - Gini-iOS-SDK/Pinning (1.0.0-alpha.1):
+  - Gini-iOS-SDK/Pinning (1.0.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
   - Kiwi (2.4.0)
@@ -20,16 +20,22 @@ DEPENDENCIES:
   - Gini-iOS-SDK/Pinning (from `./`)
   - Kiwi (~> 2.4.0)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Bolts
+    - Kiwi
+    - TrustKit
+
 EXTERNAL SOURCES:
   Gini-iOS-SDK:
-    :path: ./
+    :path: "./"
 
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
-  Gini-iOS-SDK: 5b1de7265013626e418df9781a9f5f0cbd2b9b2a
+  Gini-iOS-SDK: 50ea7250382ec595f44f043816e98f7e78ba0545
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 0dbabbd31fc2a03f4c7c928185f82a5ee842dc13
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3


### PR DESCRIPTION
Created the `GINIDocumentMetadata` object which can be now passed when creating documents.

### How to test
You can either run the example app of this repo and create documents with metadata or use it in the [GVL Example app](https://github.com/gini/gini-vision-lib-ios), passing the metadata in the methods located in the `DocumentService` (for this you have to link this Pod as a _Development pod_ in the `Podfile`).

### Merging
Automatic
