### PR TITLE
Cancellable document uploads

### DIFF
--- a/Gini-iOS-SDK/GINIDocumentTaskManager.h
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.h
@@ -151,6 +151,29 @@
  * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
  * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
  *
+ * @param fileName                  The file name of the document.
+ * @param data                      Data representing the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+
+ *
+ * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                                  Please notice that it is very unlikely that the created document is already fully processed, so
+ *                                  the extractions may not yet exist.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
  * @param fileName      The file name of the document.
  * @param data          Data representing the document.
  * @param docType       The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
@@ -164,6 +187,31 @@
                               fromData:(NSData *)data
                                docType:(NSString *)docType
                               metadata:(GINIDocumentMetadata *)metadata;
+
+/**
+ * Creates a new document with the given `doctype` from the given data.
+ * Data can be in the format of a PDF, UTF-8 text or image representation.
+ * By providing the doctype, Gini's document processing is optimized in many ways.
+ *
+ * See the [Gini API documentation](http://developer.gini.net/gini-api/html/documents.html#document-type-hints) for
+ * details and [a list of available doctypes](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ *
+ * @param fileName                  The file name of the document.
+ * @param data                      Data representing the document.
+ * @param docType                   The doctype hint for the document [Possible values](http://developer.gini.net/gini-api/html/entity_reference.html#extraction-entity-doctype).
+ * @param metadata                  (Optional) The document metadata containing any custom information regarding the upload (used later for reporting).
+ * @param cancellationToken         Cancellation token used to cancel the current task.
+ *
+ * @returns                         A `BFTask*` that will resolve to a `GINIDocument` instance representing the created document.
+ *                                  Please notice that it is very unlikely that the created document is already fully processed, so
+ *                                  the extractions may not yet exist.
+ */
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
+                              metadata:(GINIDocumentMetadata *)metadata
+                     cancellationToken:(BFCancellationToken *)cancellationToken;
+
 
 /**
  * Creates a new partial document with the given `doctype` from the given data.

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -110,6 +110,17 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 - (BFTask *)createDocumentWithFilename:(NSString *)fileName
                               fromData:(NSData *)data
                                docType:(NSString *)docType
+                     cancellationToken:(BFCancellationToken *)cancellationToken {
+    return [self createDocumentWithFilename:fileName
+                                   fromData:data
+                                    docType:docType
+                                   metadata:nil
+                          cancellationToken:cancellationToken];
+}
+
+- (BFTask *)createDocumentWithFilename:(NSString *)fileName
+                              fromData:(NSData *)data
+                               docType:(NSString *)docType
                               metadata:(GINIDocumentMetadata *)metadata {
     return [self createDocumentWithFilename:fileName
                                    fromData:data
@@ -131,7 +142,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
                                                   contentType:[data mimeType]
                                                      fileName:fileName
                                                       docType:docType
-                                                     metadata: metadata
+                                                     metadata:metadata
                                             cancellationToken:cancellationToken] continueWithSuccessBlock:^id(BFTask *task) {
         return [GINIDocument documentFromAPIResponse:task.result withDocumentManager:self];
     }];

--- a/Gini-iOS-SDK/GINIDocumentTaskManager.m
+++ b/Gini-iOS-SDK/GINIDocumentTaskManager.m
@@ -338,7 +338,7 @@ BFTask*GINIhandleHTTPerrors(BFTask *originalTask){
 - (BFTask *)updateDocument:(GINIDocument *)document {
     NSParameterAssert([document isKindOfClass:[GINIDocument class]]);
     
-    BFTask *updateTask = [[document extractions] continueWithSuccessBlock:^id(BFTask *task) {
+    BFTask *updateTask = [[self getExtractionsForDocument: document] continueWithSuccessBlock:^id(BFTask *task) {
         NSDictionary *extractions = task.result;
         NSMutableDictionary *updateExtractions = [NSMutableDictionary new];
         


### PR DESCRIPTION
Added cancellable document uploads for old document creation methods.

### How to test
Build and SDK and use the `GINIAPIAccountingType`, check the requests and see that they point to a different API.

### Merging
Automatic
