### PR TITLE
Add stored credentials deletion

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,4 +1,4 @@
-Jinja2==2.7.3
+Jinja2==2.8.1
 MarkupSafe==0.23
 Pygments==2.0.1
 Sphinx==1.2.3

--- a/Gini-iOS-SDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Gini-iOS-SDK.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Gini-iOS-SDK/GiniSDK.h
+++ b/Gini-iOS-SDK/GiniSDK.h
@@ -80,4 +80,7 @@ FOUNDATION_EXPORT NSString *const GINIInjectorAPIKey;
  */
 @property (readonly) GINIDocumentTaskManager *documentTaskManager;
 
+/// Removes the user stored credentials. Recommended when logging a different user in your app.
+- (void)removeStoredCredentials;
+
 @end

--- a/Gini-iOS-SDK/GiniSDK.m
+++ b/Gini-iOS-SDK/GiniSDK.m
@@ -57,5 +57,10 @@ NSString *const GINIInjectorAPIKey = @"API";
     return _documentTaskManager;
 }
 
+- (void)removeStoredCredentials {
+    GINIKeychainCredentialsStore *store = [_injector getInstanceOf:@protocol(GINICredentialsStore)];
+    [store removeCredentials];
+}
+
 
 @end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,11 +5,11 @@ PODS:
   - Bolts/AppLinks (1.9.0):
     - Bolts/Tasks
   - Bolts/Tasks (1.9.0)
-  - Gini-iOS-SDK (1.1.0):
-    - Gini-iOS-SDK/Core (= 1.1.0)
-  - Gini-iOS-SDK/Core (1.1.0):
+  - Gini-iOS-SDK (1.2.0):
+    - Gini-iOS-SDK/Core (= 1.2.0)
+  - Gini-iOS-SDK/Core (1.2.0):
     - Bolts (~> 1.9)
-  - Gini-iOS-SDK/Pinning (1.1.0):
+  - Gini-iOS-SDK/Pinning (1.2.0):
     - Bolts (~> 1.9)
     - TrustKit (~> 1.5)
   - Kiwi (2.4.0)
@@ -32,10 +32,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
-  Gini-iOS-SDK: 6201faff254c70c20305f11f3ccda0f534d35537
+  Gini-iOS-SDK: 6dd0d7e15c42fb3db4ee8d3a4e78a017e460296c
   Kiwi: f49c9d54b28917df5928fe44968a39ed198cb8a8
   TrustKit: b2bd5cb6a69cb17a95af87af327ecaa93c8da4bd
 
 PODFILE CHECKSUM: 0dbabbd31fc2a03f4c7c928185f82a5ee842dc13
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1


### PR DESCRIPTION
Add stored credentials deletion method to GiniSDK. Also updated `Jinja2` dependency due to a vulnerability.

### How to test
Build and SDK and use the `removeStoredCredentials` instance method.

### Merging
Automatic